### PR TITLE
fix(web): pin bootstrap to verified email + harden getClientIp vs XFF spoofing (#22, #23)

### DIFF
--- a/web/__tests__/api/users-bootstrap.test.ts
+++ b/web/__tests__/api/users-bootstrap.test.ts
@@ -1,18 +1,22 @@
 /** @jest-environment node */
 
 /**
- * Route-level tests for POST /api/users/bootstrap — the two signup-abuse
- * controls added in the signup-abuse-tier2 PR.
+ * Route-level tests for POST /api/users/bootstrap — the signup-abuse controls
+ * plus the verified-email pin (issue #22).
  *
  * The pure helpers (isDisposableEmailDomain, sanitizeDisplayName) are unit-
  * tested elsewhere; these tests pin the ROUTE wiring that those unit tests
  * can't see:
- *   - a disposable-domain email is rejected with 400 BEFORE any DB write
+ *   - the persisted email is the VERIFIED Firebase Auth email (getUser(uid)),
+ *     never the client-supplied body.email — so a bot can't authenticate with a
+ *     disposable address and store a clean one, or vice-versa,
+ *   - a disposable VERIFIED email is rejected with 400 BEFORE any DB write
  *     (bootstrapUser is never called), and
  *   - the per-IP signup rate limit short-circuits with 429 before the handler
  *     runs.
- * A regression that dropped the withRateLimit wrap, or moved the disposable
- * check after the bootstrap write, would pass every existing test but fail here.
+ * A regression that re-trusted body.email, dropped the withRateLimit wrap, or
+ * moved the disposable check after the bootstrap write, would pass the old
+ * tests but fail here.
  */
 
 import { createMockRequest, parseResponse } from './helpers/utils';
@@ -20,6 +24,15 @@ import { createMockRequest, parseResponse } from './helpers/utils';
 jest.mock('@sentry/nextjs', () => ({
   captureException: jest.fn(),
   captureMessage: jest.fn(),
+}));
+
+// Firebase Auth record lookup — the route reads the AUTHORITATIVE email from
+// getAdminAuth().getUser(uid). getAdminDb is also exported here and pulled in
+// transitively by apiAuth.server, so keep it present (unused in these tests).
+const mockGetUser = jest.fn();
+jest.mock('@/lib/firebase-admin', () => ({
+  getAdminAuth: () => ({ getUser: (...a: unknown[]) => mockGetUser(...a) }),
+  getAdminDb: jest.fn(),
 }));
 
 const mockRequireSessionOrIdToken = jest.fn();
@@ -64,6 +77,7 @@ describe('POST /api/users/bootstrap — abuse controls', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRequireSessionOrIdToken.mockResolvedValue('uid-test');
+    mockGetUser.mockResolvedValue({ uid: 'uid-test', email: 'real@gmail.com' });
     mockBootstrapUser.mockResolvedValue({
       kind: 'created',
       uid: 'uid-test',
@@ -80,19 +94,33 @@ describe('POST /api/users/bootstrap — abuse controls', () => {
     });
   });
 
-  it('rejects a disposable-domain email with 400 and never writes the user doc', async () => {
-    const res = await POST(bootstrapReq({ email: 'bot@mailinator.com' }));
+  it('rejects when the VERIFIED account email is a disposable domain — even if body.email is clean', async () => {
+    // Bot authenticates with a disposable address but POSTs a clean one.
+    mockGetUser.mockResolvedValue({ uid: 'uid-test', email: 'bot@mailinator.com' });
+    const res = await POST(bootstrapReq({ email: 'clean@gmail.com' }));
     const { status, body } = await parseResponse(res);
     expect(status).toBe(400);
     expect(JSON.stringify(body)).toMatch(/disposable/i);
     expect(mockBootstrapUser).not.toHaveBeenCalled();
   });
 
-  it('lets a normal email through to bootstrap', async () => {
-    const res = await POST(bootstrapReq({ email: 'real@gmail.com', displayName: 'Real Person' }));
+  it('persists the VERIFIED token email, never the client-supplied body.email', async () => {
+    const res = await POST(
+      bootstrapReq({ email: 'attacker-controlled@evil.com', displayName: 'Real Person' }),
+    );
     const { status } = await parseResponse(res);
     expect(status).toBe(200);
     expect(mockBootstrapUser).toHaveBeenCalledTimes(1);
+    const input = mockBootstrapUser.mock.calls[0][1] as { email: string };
+    expect(input.email).toBe('real@gmail.com'); // from getUser(uid), not the body
+  });
+
+  it('rejects with 400 when the account has no usable verified email', async () => {
+    mockGetUser.mockResolvedValue({ uid: 'uid-test', email: undefined });
+    const res = await POST(bootstrapReq({ email: 'real@gmail.com' }));
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(mockBootstrapUser).not.toHaveBeenCalled();
   });
 
   it('returns 429 and never writes when the signup rate limit is exceeded', async () => {
@@ -106,13 +134,6 @@ describe('POST /api/users/bootstrap — abuse controls', () => {
     const res = await POST(bootstrapReq({ email: 'real@gmail.com' }));
     const { status } = await parseResponse(res);
     expect(status).toBe(429);
-    expect(mockBootstrapUser).not.toHaveBeenCalled();
-  });
-
-  it('rejects a malformed email with 400 before the disposable check (validation order)', async () => {
-    const res = await POST(bootstrapReq({ email: 'not-an-email' }));
-    const { status } = await parseResponse(res);
-    expect(status).toBe(400);
     expect(mockBootstrapUser).not.toHaveBeenCalled();
   });
 });

--- a/web/__tests__/lib/rateLimit.test.ts
+++ b/web/__tests__/lib/rateLimit.test.ts
@@ -5,14 +5,38 @@ import type { Ratelimit } from '@upstash/ratelimit';
 import { getClientIp, checkRateLimit, getRateLimitHeaders } from '@/lib/rateLimit';
 
 describe('getClientIp', () => {
-  it('extracts first IP from x-forwarded-for', () => {
+  it('prefers CF-Connecting-IP (Cloudflare-set, unspoofable) over X-Forwarded-For', () => {
+    const req = new NextRequest(new URL('http://localhost/test'), {
+      headers: {
+        'cf-connecting-ip': '203.0.113.7',
+        'x-forwarded-for': '1.2.3.4, 5.6.7.8', // client-seeded — must be ignored
+      },
+    });
+    expect(getClientIp(req)).toBe('203.0.113.7');
+  });
+
+  it('takes the RIGHT-most x-forwarded-for hop (proxy-appended), not the client-seeded left', () => {
     const req = new NextRequest(new URL('http://localhost/test'), {
       headers: { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
     });
-    expect(getClientIp(req)).toBe('1.2.3.4');
+    expect(getClientIp(req)).toBe('5.6.7.8');
   });
 
-  it('returns x-real-ip when no x-forwarded-for', () => {
+  it('resists X-Forwarded-For rotation — a forged left entry cannot mint a fresh bucket', () => {
+    // Attacker prepends a rotating fake; the trusted edge appends the real IP.
+    // Both requests must resolve to the SAME (real) IP so the rate-limit bucket
+    // is stable regardless of what the client pre-seeds.
+    const a = new NextRequest(new URL('http://localhost/test'), {
+      headers: { 'x-forwarded-for': '9.9.9.9, 198.51.100.5' },
+    });
+    const b = new NextRequest(new URL('http://localhost/test'), {
+      headers: { 'x-forwarded-for': '8.8.8.8, 198.51.100.5' },
+    });
+    expect(getClientIp(a)).toBe('198.51.100.5');
+    expect(getClientIp(b)).toBe('198.51.100.5');
+  });
+
+  it('returns x-real-ip when no cf / x-forwarded-for', () => {
     const req = new NextRequest(new URL('http://localhost/test'), {
       headers: { 'x-real-ip': '10.0.0.1' },
     });
@@ -29,6 +53,41 @@ describe('getClientIp', () => {
   it('returns unknown when no proxy headers', () => {
     const req = new NextRequest(new URL('http://localhost/test'));
     expect(getClientIp(req)).toBe('unknown');
+  });
+
+  it('clamps a malformed IP header to unknown (no injected rate-limit key)', () => {
+    const req = new NextRequest(new URL('http://localhost/test'), {
+      headers: { 'cf-connecting-ip': 'not-an-ip <script>' },
+    });
+    expect(getClientIp(req)).toBe('unknown');
+  });
+
+  it('caps an over-long IP token at 64 chars', () => {
+    const req = new NextRequest(new URL('http://localhost/test'), {
+      headers: { 'cf-connecting-ip': '1'.repeat(100) },
+    });
+    expect(getClientIp(req).length).toBe(64);
+  });
+
+  it('shape-clamps the right-most X-Forwarded-For hop too — the value used as the rate-limit key', () => {
+    // The XFF branch is the identifier on the non-Cloudflare path, so its clamp
+    // must be pinned, not just CF-Connecting-IP's.
+    const malformed = new NextRequest(new URL('http://localhost/test'), {
+      headers: { 'x-forwarded-for': '5.6.7.8, junk!<script>' },
+    });
+    expect(getClientIp(malformed)).toBe('unknown');
+
+    const overlong = new NextRequest(new URL('http://localhost/test'), {
+      headers: { 'x-forwarded-for': `1.2.3.4, ${'9'.repeat(100)}` },
+    });
+    expect(getClientIp(overlong).length).toBe(64);
+  });
+
+  it('preserves an IPv6 client address', () => {
+    const req = new NextRequest(new URL('http://localhost/test'), {
+      headers: { 'cf-connecting-ip': '2001:db8::1' },
+    });
+    expect(getClientIp(req)).toBe('2001:db8::1');
   });
 });
 

--- a/web/app/api/legal/dmca/route.ts
+++ b/web/app/api/legal/dmca/route.ts
@@ -13,6 +13,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb } from '@/lib/firebase-admin';
+import { getClientIp } from '@/lib/rateLimit';
 import { FieldValue } from 'firebase-admin/firestore';
 import {
   rateLimitVerdict,
@@ -72,8 +73,12 @@ export async function POST(request: NextRequest) {
 
     // rate-limit per (email, ip) to keep the review queue functional
     // against a flood. firestore count() via admin SDK to tally recent
-    // submissions in the same hour.
-    const sourceIp = sanitiseIp(request.headers.get('x-forwarded-for'));
+    // submissions in the same hour. The IP is derived via the shared,
+    // spoof-resistant `getClientIp` (CF-Connecting-IP first, then the
+    // trusted right-most X-Forwarded-For hop) — a public endpoint with no
+    // token fallback, so a forgeable left-most XFF here would let a flooder
+    // mint unlimited per-IP buckets (issue #23).
+    const sourceIp = getClientIp(request);
     const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
 
     const col = db.collection('dmca_notices');
@@ -151,14 +156,4 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     return problemFromError(err, 'legal/dmca');
   }
-}
-
-/** Extract the first hop of `x-forwarded-for` and clamp to IPv4/IPv6 shape. */
-function sanitiseIp(header: string | null): string {
-  if (!header) return 'unknown';
-  const first = header.split(',')[0].trim();
-  // Loose character allowlist — we're not parsing the IP, just pinning
-  // it so the firestore equality query is deterministic.
-  if (!/^[0-9a-fA-F.:]+$/.test(first)) return 'unknown';
-  return first.slice(0, 64);
 }

--- a/web/app/api/users/bootstrap/route.ts
+++ b/web/app/api/users/bootstrap/route.ts
@@ -22,12 +22,15 @@
  * Idempotent — calling twice for the same uid is a no-op (returns
  * `alreadyExists: true`).
  *
- * Body: `{ email, displayName?, timezone? }`. The `uid` is taken from the
- * verified token, not from the body, so a caller cannot bootstrap a doc
- * for someone else.
+ * Body: `{ displayName?, timezone? }`. Both the `uid` AND the `email` are
+ * taken from the verified auth context — the uid from the bearer/session and
+ * the email from the Firebase Auth record (`getUser(uid).email`) — never from
+ * the body. A caller therefore cannot bootstrap a doc for someone else, nor
+ * persist a falsified email (issue #22). Any `email` in the body is ignored.
  */
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { getAdminAuth } from '@/lib/firebase-admin';
 import {
   ApiAuthError,
   requireSessionOrIdToken,
@@ -44,7 +47,9 @@ import { isDisposableEmailDomain } from '@/lib/disposableEmailDomains';
 import { readAndParseJsonBody } from '../../_shared';
 
 interface BootstrapBody {
-  email?: unknown;
+  // `email` is intentionally absent: the authoritative address comes from the
+  // verified Firebase Auth record, not the body (issue #22). A body-supplied
+  // email is ignored.
   displayName?: unknown;
   timezone?: unknown;
 }
@@ -72,16 +77,29 @@ async function handleBootstrap(request: NextRequest): Promise<NextResponse> {
       async () => {
         const body = parsed.body as BootstrapBody;
 
-        if (typeof body.email !== 'string' || !EMAIL_REGEX.test(body.email)) {
+        // Resolve the AUTHORITATIVE email from the Firebase Auth record, not
+        // from the request body. bootstrapUser writes via the Admin SDK, which
+        // bypasses the `email == request.auth.token.email` pin in
+        // firestore.rules — so trusting body.email would let a caller
+        // authenticate with one address (e.g. a disposable one that slips past
+        // the block below) while persisting another, or store a wholly
+        // falsified address. (issue #22)
+        let verifiedEmail: string | undefined;
+        try {
+          verifiedEmail = (await getAdminAuth().getUser(userId)).email?.trim();
+        } catch (err) {
+          return problemFromError(err, 'users/bootstrap:getUser');
+        }
+        if (!verifiedEmail || !EMAIL_REGEX.test(verifiedEmail)) {
           return problemValidation(
-            'email is required and must be a valid email address',
-            { 'body.email': ['must be a valid email address'] },
+            'no verified email is associated with this account',
+            { email: ['account has no usable verified email address'] },
           );
         }
-        if (isDisposableEmailDomain(body.email)) {
+        if (isDisposableEmailDomain(verifiedEmail)) {
           return problemValidation(
             'email address uses a disallowed disposable domain',
-            { 'body.email': ['disposable email domains are not permitted'] },
+            { email: ['disposable email domains are not permitted'] },
           );
         }
         if (
@@ -111,7 +129,7 @@ async function handleBootstrap(request: NextRequest): Promise<NextResponse> {
           },
           {
             uid: userId,
-            email: body.email,
+            email: verifiedEmail,
             displayName:
               typeof body.displayName === 'string' ? body.displayName : '',
             timezone:

--- a/web/lib/rateLimit.ts
+++ b/web/lib/rateLimit.ts
@@ -205,31 +205,70 @@ export function getDisplayAlertRateLimit(eventType: string) {
 }
 
 /**
- * Extract client IP from NextRequest
- * Handles proxies (Railway, Cloudflare, etc.)
+ * Extract the client IP from a request, resistant to header spoofing.
+ *
+ * A client can set any request header, so header precedence runs from
+ * infrastructure-controlled (unforgeable) to weakest — the only safe sources
+ * are ones a trusted hop OVERWRITES or APPENDS:
+ *
+ *   1. `CF-Connecting-IP` — Cloudflare rewrites this at its edge on every
+ *      request, so a client-supplied value never survives. owlette.app is
+ *      fronted by a Cloudflare load balancer (see `infra/cloudflare/`,
+ *      Railway primary + Vercel standby), making this authoritative in prod.
+ *   2. `X-Forwarded-For`, read RIGHT-TO-LEFT. Each proxy APPENDS the address
+ *      it received the connection from, so the right-most entry is the one our
+ *      own edge added; everything to its left is whatever the client
+ *      pre-seeded. Taking the LEFT-most (the previous behaviour) let a caller
+ *      rotate `X-Forwarded-For` to mint a fresh rate-limit bucket per request
+ *      and defeat the per-IP cap (issue #23). We take the right-most entry,
+ *      which the single trusted hop in front of the app (Railway/Vercel edge,
+ *      when Cloudflare is not fronting — e.g. local/dev) controls.
+ *   3. `X-Real-IP` / `X-Railway-IP` — single-value proxy headers.
+ *   4. `'unknown'` — no usable signal; such callers share one bucket.
+ *
+ * The chosen value is shape-clamped (IP charset, ≤64 chars) so a malformed
+ * header can't become an oversized or injected rate-limit key.
  */
 export function getClientIp(request: NextRequest): string {
-  // Check common proxy headers
+  const cfConnectingIp = request.headers.get('cf-connecting-ip');
+  if (cfConnectingIp) {
+    return normalizeIp(cfConnectingIp);
+  }
+
   const forwardedFor = request.headers.get('x-forwarded-for');
   if (forwardedFor) {
-    // x-forwarded-for can be a comma-separated list: "client, proxy1, proxy2"
+    // Right-most = appended by the trusted edge closest to us; entries to its
+    // left are client-controlled. See the doc comment above.
     const ips = forwardedFor.split(',');
-    return ips[0].trim();
+    return normalizeIp(ips[ips.length - 1]);
   }
 
   const realIp = request.headers.get('x-real-ip');
   if (realIp) {
-    return realIp;
+    return normalizeIp(realIp);
   }
 
   // Railway-specific header
   const railwayIp = request.headers.get('x-railway-ip');
   if (railwayIp) {
-    return railwayIp;
+    return normalizeIp(railwayIp);
   }
 
   // Fallback to connection IP (may not work in serverless)
   return 'unknown';
+}
+
+/**
+ * Trim and shape-clamp an IP token. Returns 'unknown' when the value isn't
+ * IP-like, so a junk or hostile header can't become a Redis rate-limit key.
+ * Accepts the IPv4/IPv6 charset only (digits, hex, '.', ':').
+ */
+function normalizeIp(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || !/^[0-9a-fA-F.:]+$/.test(trimmed)) {
+    return 'unknown';
+  }
+  return trimmed.slice(0, 64);
 }
 
 /**

--- a/web/openapi.yaml
+++ b/web/openapi.yaml
@@ -5806,10 +5806,11 @@ paths:
       summary: bootstrap the caller user document
       description: |
         Creates `users/{uid}` for the authenticated caller on first sign-in
-        or sign-up. The uid is taken from the verified session or Firebase
-        ID token, not from the request body. This route intentionally does
-        not use the platform superadmin handler because a new caller has no
-        user document yet.
+        or sign-up. Both the uid AND the email are taken from the verified
+        session / Firebase Auth record (`getUser(uid).email`), never from the
+        request body — a body-supplied `email` is ignored. This route
+        intentionally does not use the platform superadmin handler because a
+        new caller has no user document yet.
       security:
         - firebaseIdToken: []
       parameters:
@@ -5823,11 +5824,11 @@ paths:
           application/json:
             schema:
               type: object
-              required: [email]
+              description: |
+                The email is not accepted here; it is resolved server-side
+                from the verified auth record. Only optional profile fields
+                are read from the body.
               properties:
-                email:
-                  type: string
-                  format: email
                 displayName:
                   type: string
                   maxLength: 200


### PR DESCRIPTION
Closes the two pre-existing signup-abuse findings surfaced during the #20 cross-model review and filed as #22/#23. Neither was introduced by #20 — the new disposable/limiter controls just inherited them.

## #22 — bootstrap trusted client `body.email`
`/api/users/bootstrap` validated and persisted the **client-supplied** `body.email` for both the disposable-domain block and `users/{uid}.email`. The write goes through the Admin SDK, so it bypasses the `email == request.auth.token.email` pin in `firestore.rules` — a bot could authenticate with a disposable address (slipping past nothing) while persisting a clean/falsified one, or store any forged address.

**Fix:** the email is now read from the verified Firebase Auth record (`getAdminAuth().getUser(uid).email`) for **both** the disposable check and the persisted value. `body.email` is ignored. The flow does **not** gate on `emailVerified` (it must not — bootstrap runs at sign-up, before verification).

## #23 — `getClientIp` trusted spoofable left-most XFF
`getClientIp()` returned the **left-most** `X-Forwarded-For` entry, which is client-controlled behind Railway/Cloudflare — a caller could rotate XFF to mint a fresh per-IP rate-limit bucket per request and defeat the 10/hr signup cap.

**Fix:** precedence is now `CF-Connecting-IP` (Cloudflare-set, unspoofable in prod — owlette.app is behind the CF LB) → trusted **right-most** XFF hop → `x-real-ip`/`x-railway-ip` → `unknown`, each shape-clamped (`normalizeIp`, IP charset + ≤64 chars) so a hostile header can't become a Redis key. The public **DMCA** route (no token fallback — more exposed) had the identical left-most-XFF spoof in a local `sanitiseIp`; it now uses the shared hardened `getClientIp`.

## Verification
- lint + `tsc --noEmit` clean; **full web unit suite: 148 suites / 2513 passed / 0 failed**.
- New/updated tests pin: CF precedence, right-most XFF, rotation-stability, shape clamp on **both** the CF and XFF branches, IPv6 preserved, verified-email persistence (not body.email), disposable-on-verified-email, and no-verified-email → 400.
- A 5-lens adversarial review fleet (spoof-resistance, IP regression/over-blocking, bootstrap-pin completeness, DMCA sibling, test quality) with a per-finding refutation pass returned **0 confirmed findings**; the only notes were low-severity hardening observations (residual XFF risk on a hypothetical no-proxy origin) deemed acceptable given prod always carries CF-Connecting-IP.

Refs #22, #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)