### PR TITLE
fix(web): repair dangling cortex tool calls so chats can't be bricked

### DIFF
--- a/web/__tests__/lib/cortex/repairMessages.test.ts
+++ b/web/__tests__/lib/cortex/repairMessages.test.ts
@@ -1,0 +1,259 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the Cortex history repair (repairDanglingToolParts).
+ *
+ * Pins down:
+ *   1. clean histories pass through untouched (same references)
+ *   2. dangling `input-available` / `input-streaming` tool parts on a
+ *      superseded assistant turn become terminal `output-error` parts
+ *   3. unanswered `approval-requested` parts superseded by a later user
+ *      message are resolved (approval stripped, error output)
+ *   4. the final in-flight assistant message is never touched (the tier-3
+ *      approval round-trip depends on it)
+ *   5. regression pin against the real AI SDK: the broken shape makes
+ *      convertToModelMessages throw MissingToolResultsError; the repaired
+ *      shape converts cleanly
+ */
+
+import { convertToModelMessages, streamText, type UIMessage } from 'ai';
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test';
+import {
+  repairDanglingToolParts,
+  LOST_RESULT_ERROR,
+  SUPERSEDED_APPROVAL_ERROR,
+} from '@/lib/cortex/repairMessages';
+
+function userMsg(id: string, text: string): UIMessage {
+  return { id, role: 'user', parts: [{ type: 'text', text }] } as UIMessage;
+}
+
+function assistantMsg(id: string, parts: unknown[]): UIMessage {
+  return { id, role: 'assistant', parts } as UIMessage;
+}
+
+const danglingToolPart = {
+  type: 'tool-execute_script',
+  toolCallId: 'toolu_dangling_1',
+  state: 'input-available',
+  input: { script: 'sfc /scannow', timeout_seconds: 1800 },
+};
+
+const completedToolPart = {
+  type: 'tool-execute_script',
+  toolCallId: 'toolu_done_1',
+  state: 'output-available',
+  input: { script: 'Get-Date' },
+  output: { exit_code: 0, stdout: 'ok' },
+};
+
+describe('repairDanglingToolParts', () => {
+  it('returns clean histories untouched (same message references)', () => {
+    const messages = [
+      userMsg('u1', 'run a script'),
+      assistantMsg('a1', [{ type: 'text', text: 'done' }, completedToolPart]),
+      userMsg('u2', 'thanks'),
+    ];
+
+    const { messages: out, repairedToolCallIds } = repairDanglingToolParts(messages);
+
+    expect(repairedToolCallIds).toEqual([]);
+    expect(out[1]).toBe(messages[1]);
+  });
+
+  it('repairs a dangling input-available part on a superseded turn', () => {
+    const messages = [
+      userMsg('u1', 'run sfc and dism'),
+      assistantMsg('a1', [{ type: 'text', text: 'running both' }, completedToolPart, danglingToolPart]),
+      userMsg('u2', 'still running?'),
+    ];
+
+    const { messages: out, repairedToolCallIds } = repairDanglingToolParts(messages);
+
+    expect(repairedToolCallIds).toEqual(['toolu_dangling_1']);
+    const parts = out[1].parts as Array<Record<string, unknown>>;
+    expect(parts[1]).toBe(completedToolPart); // untouched sibling
+    expect(parts[2]).toMatchObject({
+      type: 'tool-execute_script',
+      toolCallId: 'toolu_dangling_1',
+      state: 'output-error',
+      errorText: LOST_RESULT_ERROR,
+      input: danglingToolPart.input, // captured input preserved
+    });
+  });
+
+  it('repairs input-streaming parts and defaults missing input to {}', () => {
+    const messages = [
+      userMsg('u1', 'go'),
+      assistantMsg('a1', [
+        { type: 'tool-execute_script', toolCallId: 'toolu_stream_1', state: 'input-streaming' },
+      ]),
+      userMsg('u2', 'hello?'),
+    ];
+
+    const { messages: out, repairedToolCallIds } = repairDanglingToolParts(messages);
+
+    expect(repairedToolCallIds).toEqual(['toolu_stream_1']);
+    expect((out[1].parts as Array<Record<string, unknown>>)[0]).toMatchObject({
+      state: 'output-error',
+      errorText: LOST_RESULT_ERROR,
+      input: {},
+    });
+  });
+
+  it('resolves an unanswered approval superseded by a later user message', () => {
+    const messages = [
+      userMsg('u1', 'reboot it'),
+      assistantMsg('a1', [
+        {
+          type: 'tool-reboot_machine',
+          toolCallId: 'toolu_approval_1',
+          state: 'approval-requested',
+          input: {},
+          approval: { id: 'appr_1' },
+        },
+      ]),
+      userMsg('u2', 'actually, wait'),
+    ];
+
+    const { messages: out, repairedToolCallIds } = repairDanglingToolParts(messages);
+
+    expect(repairedToolCallIds).toEqual(['toolu_approval_1']);
+    const part = (out[1].parts as Array<Record<string, unknown>>)[0];
+    expect(part).toMatchObject({ state: 'output-error', errorText: SUPERSEDED_APPROVAL_ERROR });
+    expect(part.approval).toBeUndefined();
+  });
+
+  it('never touches the final in-flight assistant message (approval round-trip)', () => {
+    const pendingApproval = assistantMsg('a1', [
+      {
+        type: 'tool-reboot_machine',
+        toolCallId: 'toolu_pending_1',
+        state: 'approval-requested',
+        input: {},
+        approval: { id: 'appr_1' },
+      },
+    ]);
+    const messages = [userMsg('u1', 'reboot it'), pendingApproval];
+
+    const { messages: out, repairedToolCallIds } = repairDanglingToolParts(messages);
+
+    expect(repairedToolCallIds).toEqual([]);
+    expect(out[1]).toBe(pendingApproval);
+  });
+
+  it('preserves toolName on repaired dynamic-tool parts', () => {
+    const messages = [
+      userMsg('u1', 'go'),
+      assistantMsg('a1', [
+        {
+          type: 'dynamic-tool',
+          toolName: 'execute_script',
+          toolCallId: 'toolu_dyn_1',
+          state: 'input-available',
+          input: { script: 'dir' },
+        },
+      ]),
+      userMsg('u2', 'and?'),
+    ];
+
+    const { messages: out } = repairDanglingToolParts(messages);
+
+    expect((out[1].parts as Array<Record<string, unknown>>)[0]).toMatchObject({
+      type: 'dynamic-tool',
+      toolName: 'execute_script',
+      state: 'output-error',
+    });
+  });
+
+  it('leaves output-error and approval-responded parts untouched', () => {
+    const erroredPart = {
+      type: 'tool-execute_script',
+      toolCallId: 'toolu_err_1',
+      state: 'output-error',
+      input: {},
+      errorText: 'agent said no',
+    };
+    const respondedPart = {
+      type: 'tool-reboot_machine',
+      toolCallId: 'toolu_resp_1',
+      state: 'approval-responded',
+      input: {},
+      approval: { id: 'appr_2', approved: false, reason: 'denied' },
+    };
+    const messages = [
+      userMsg('u1', 'go'),
+      assistantMsg('a1', [erroredPart, respondedPart]),
+      userMsg('u2', 'ok'),
+    ];
+
+    const { messages: out, repairedToolCallIds } = repairDanglingToolParts(messages);
+
+    expect(repairedToolCallIds).toEqual([]);
+    expect(out[1]).toBe(messages[1]);
+  });
+
+  // The regression pin this module exists for: the exact prod failure shape
+  // (dangling tool call followed by user messages) makes streamText's prompt
+  // preparation throw MissingToolResultsError ("Tool result is missing for
+  // tool call toolu_…"); the repaired history streams cleanly. Note the throw
+  // happens inside streamText (convertToLanguageModelPrompt), NOT in
+  // convertToModelMessages — so the pin must exercise streamText itself.
+  it('unbricks streamText for the prod failure shape', async () => {
+    const broken = [
+      userMsg('u1', 'run sfc /scannow and DISM in parallel'),
+      assistantMsg('a1', [
+        { type: 'text', text: "I'll run both." },
+        completedToolPart,
+        danglingToolPart,
+      ]),
+      userMsg('u2', 'looks like one is still running, right?'),
+      userMsg('u3', 'still running?'),
+    ];
+
+    async function streamErrors(messages: UIMessage[]): Promise<unknown[]> {
+      const errors: unknown[] = [];
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async () => ({
+            stream: simulateReadableStream({
+              chunks: [
+                { type: 'text-start', id: 't1' },
+                { type: 'text-delta', id: 't1', delta: 'ok' },
+                { type: 'text-end', id: 't1' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                },
+              ],
+            }),
+          }),
+        }),
+        messages: await convertToModelMessages(messages),
+        onError: ({ error }) => {
+          errors.push(error);
+        },
+      });
+      await result.consumeStream();
+      return errors;
+    }
+
+    const brokenErrors = await streamErrors(broken);
+    expect(brokenErrors.some((e) => /missing for tool call.*toolu_dangling_1/.test(String(e)))).toBe(
+      true,
+    );
+
+    const { messages: repaired } = repairDanglingToolParts(broken);
+    const repairedErrors = await streamErrors(repaired);
+    expect(repairedErrors).toEqual([]);
+
+    // The dangling call now has a matching error tool-result in the model
+    // messages, which is what satisfies the SDK's validation.
+    const modelMessages = await convertToModelMessages(repaired);
+    const toolResults = modelMessages
+      .filter((m) => m.role === 'tool')
+      .flatMap((m) => m.content as Array<{ type: string; toolCallId?: string }>);
+    expect(toolResults.some((c) => c.toolCallId === 'toolu_dangling_1')).toBe(true);
+  });
+});

--- a/web/app/api/cortex/route.ts
+++ b/web/app/api/cortex/route.ts
@@ -29,6 +29,7 @@ import {
   buildExecutableTools,
   type SiteAccessLevel,
 } from '@/lib/cortex-utils.server';
+import { repairDanglingToolParts } from '@/lib/cortex/repairMessages';
 
 const SITE_TARGET_ID = '__site__';
 
@@ -389,13 +390,23 @@ async function handleServerSideLLM(
 
   const model = createModel(llmConfig);
 
+  // Repair dangling tool parts (stream died mid-tool-call, or an approval
+  // was superseded) so convertToModelMessages can't throw
+  // MissingToolResultsError and permanently brick the conversation.
+  const { messages: repairedMessages, repairedToolCallIds } = repairDanglingToolParts(messages);
+  if (repairedToolCallIds.length > 0) {
+    console.warn(
+      `[cortex] repaired ${repairedToolCallIds.length} dangling tool part(s) in chat ${chatId}: ${repairedToolCallIds.join(', ')}`,
+    );
+  }
+
   const result = streamText({
     model,
     system: buildSystemPrompt(machineName || machineId, false, processes),
     // Convert with the built tools so per-tool toModelOutput hooks (e.g.
     // capture_screenshot → image-url) project prior-turn tool outputs into
     // model content, not just on the turn they were produced.
-    messages: await convertToModelMessages(messages, { tools: executableTools }),
+    messages: await convertToModelMessages(repairedMessages, { tools: executableTools }),
     tools: executableTools,
     stopWhen: stepCountIs(10),
   });
@@ -436,10 +447,19 @@ async function handleSiteWideMode(
 
   const model = createModel(llmConfig);
 
+  // Same dangling-tool-part repair as the single-machine path — see
+  // handleServerSideLLM.
+  const { messages: repairedMessages, repairedToolCallIds } = repairDanglingToolParts(messages);
+  if (repairedToolCallIds.length > 0) {
+    console.warn(
+      `[cortex] repaired ${repairedToolCallIds.length} dangling tool part(s) in chat ${chatId}: ${repairedToolCallIds.join(', ')}`,
+    );
+  }
+
   const result = streamText({
     model,
     system: buildSystemPrompt('', true),
-    messages: await convertToModelMessages(messages, { tools: executableTools }),
+    messages: await convertToModelMessages(repairedMessages, { tools: executableTools }),
     tools: executableTools,
     stopWhen: stepCountIs(10),
   });

--- a/web/lib/cortex/repairMessages.ts
+++ b/web/lib/cortex/repairMessages.ts
@@ -1,0 +1,111 @@
+/**
+ * History repair for Cortex UIMessages.
+ *
+ * When a chat stream dies mid-tool-call (proxy idle timeout, page reload,
+ * network drop), the persisted history keeps the tool part in an `input-*`
+ * state — a tool call with no output. `convertToModelMessages` throws
+ * `MissingToolResultsError` on such history, which permanently bricks the
+ * conversation: every subsequent send (and every retry) replays the same
+ * broken messages and fails identically.
+ *
+ * `repairDanglingToolParts` rewrites those parts to a terminal `output-error`
+ * state so the model sees an honest "result lost" outcome and the chat can
+ * continue. Unanswered tier-3 approval requests that were superseded by a
+ * later user message are resolved the same way (the tool never executed).
+ *
+ * Only assistant turns already superseded by a later user message are
+ * touched — the final assistant message may legitimately be mid-flight
+ * (an approval round-trip about to resume) and passes through untouched.
+ */
+
+import type { UIMessage } from 'ai';
+
+type UIMessagePart = UIMessage['parts'][number];
+
+interface ToolLikePart {
+  type: string;
+  state: string;
+  toolCallId: string;
+  input?: unknown;
+}
+
+export const LOST_RESULT_ERROR =
+  'result lost: the connection dropped before the tool result arrived. ' +
+  'The command may still have completed on the machine — re-run the tool or verify if needed.';
+
+export const SUPERSEDED_APPROVAL_ERROR =
+  'approval request superseded: the user sent a new message before approving or denying, ' +
+  'so the tool was never executed. Ask again if it is still needed.';
+
+function isToolPart(part: UIMessagePart): part is UIMessagePart & ToolLikePart {
+  return (
+    typeof part === 'object' &&
+    part !== null &&
+    'state' in part &&
+    (part.type === 'dynamic-tool' || part.type.startsWith('tool-'))
+  );
+}
+
+/**
+ * Convert a dangling tool part to `output-error`, preserving identity fields
+ * (`type`, `toolCallId`, and `toolName` for dynamic-tool parts) and the
+ * captured input. Any pending `approval` is dropped — an unresolved
+ * `tool-approval-request` must not reach the model alongside the error result.
+ */
+function toErrorPart(part: UIMessagePart & ToolLikePart, errorText: string): UIMessagePart {
+  const { approval: _approval, output: _output, ...rest } = part as ToolLikePart & {
+    approval?: unknown;
+    output?: unknown;
+  };
+  return {
+    ...rest,
+    state: 'output-error',
+    input: part.input ?? {},
+    errorText,
+  } as UIMessagePart;
+}
+
+export interface RepairResult {
+  messages: UIMessage[];
+  /** Tool call ids that were rewritten — empty when the history was clean. */
+  repairedToolCallIds: string[];
+}
+
+export function repairDanglingToolParts(messages: UIMessage[]): RepairResult {
+  const repairedToolCallIds: string[] = [];
+
+  let lastUserIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'user') {
+      lastUserIndex = i;
+      break;
+    }
+  }
+
+  const repaired = messages.map((message, index) => {
+    // Assistant turns after the last user message are still in flight
+    // (e.g. awaiting an approval response) — leave them untouched.
+    if (message.role !== 'assistant' || index > lastUserIndex) return message;
+
+    let changed = false;
+    const parts = message.parts.map((part) => {
+      if (!isToolPart(part)) return part;
+
+      if (part.state === 'input-streaming' || part.state === 'input-available') {
+        changed = true;
+        repairedToolCallIds.push(part.toolCallId);
+        return toErrorPart(part, LOST_RESULT_ERROR);
+      }
+      if (part.state === 'approval-requested') {
+        changed = true;
+        repairedToolCallIds.push(part.toolCallId);
+        return toErrorPart(part, SUPERSEDED_APPROVAL_ERROR);
+      }
+      return part;
+    });
+
+    return changed ? { ...message, parts } : message;
+  });
+
+  return { messages: repaired, repairedToolCallIds };
+}


### PR DESCRIPTION
## Summary

Hotfix for the prod-visible Cortex failure: when a chat stream dies mid-tool-call (proxy idle timeout on long scripts like `sfc /scannow`, page reload, network drop), the history keeps a tool call with no output and every subsequent send fails with `MissingToolResultsError` ("Tool result is missing for tool call toolu_…"). Retry cannot recover once a newer user message exists — the conversation is permanently bricked (live example: chat_1783343936166_0kympp).

`repairDanglingToolParts` runs before `convertToModelMessages` on both server LLM paths and rewrites dangling tool parts to terminal `output-error` states ("result lost — may still have completed on the machine"), and resolves tier-3 approvals superseded by a newer message. The final in-flight assistant message is never touched, preserving the approval round-trip.

This is the stop-the-bleeding slice of the larger Cortex async-turns plan (background tool execution, cancellation, reattach) — it lands the unbricked baseline that work builds on.

## Verification
- 8 new unit tests including a real-SDK regression pin (MockLanguageModelV3): the exact prod failure shape errors through `streamText`, the repaired history streams clean
- Local preflight: lint 0 errors, tsc clean, 2550 unit tests green, e2e 294 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)