### PR TITLE
ci: add Dependabot + zizmor Actions-security scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+
+updates:
+  # GitHub Actions across all workflows (.github/workflows/*), grouped into one
+  # weekly PR. Dependabot bumps version tags today; once actions are pinned to
+  # SHAs it bumps the SHA and its trailing "# vX" comment together.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci
+
+  # Node dependencies. Each of these has its own package-lock.json: the repo
+  # root, the CLI, the Cloudflare Functions, the published Node SDK, and the web
+  # app. Minor/patch bumps are grouped; majors open their own PR.
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /cli
+      - /functions
+      - /sdks/node
+      - /web
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps
+
+  # Python dependencies: the agent, docs toolchain, the published Python SDK,
+  # and the integration / agent-runner test harnesses.
+  - package-ecosystem: pip
+    directories:
+      - /agent
+      - /docs
+      - /sdks/python
+      - /test/integration
+      - /test/infra/agent-runner
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      pip-minor-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: Actions Security
+
+# Static analysis of the GitHub Actions workflows themselves (zizmor). Runs on
+# every PR and on pushes to main so misconfigurations (unpinned actions, leaked
+# credentials, injection, over-broad permissions) are caught before they ship.
+#
+# This repo is public, so results are uploaded as SARIF to the Security tab
+# (free code scanning). In this mode zizmor reports findings without failing the
+# job, so it does not block the existing publish workflows — triage the findings
+# (e.g. pinning actions to SHAs) from the Security tab.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+# Least-privilege default: grant nothing at the top level, widen per job.
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      security-events: write # upload SARIF to the Security tab (public repo -> free)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7


### PR DESCRIPTION
## What
- **Dependabot** — weekly updates, grouped minor/patch:
  - **npm** — `/`, `/cli`, `/functions`, `/sdks/node`, `/web`
  - **pip** — `/agent`, `/docs`, `/sdks/python`, `/test/integration`, `/test/infra/agent-runner`
  - **github-actions** — `/`
- **zizmor** — GitHub Actions security scan. This repo is **public**, so zizmor uploads SARIF to the **Security tab** (free code scanning) in **non-blocking** mode — it does not fail the existing publish workflows.

## Heads up: existing findings
zizmor currently reports **61 findings (29 high)** across the 7 existing workflows — mostly **unpinned actions** in the publish pipelines (`actions/checkout@v6`, `actions/setup-node@v6`, `pypa/gh-action-pypi-publish@release/v1`, …). This PR **surfaces** them in the Security tab without blocking anything.

**Recommended follow-up:** pin those actions to commit SHAs (Dependabot then keeps them current). Since this repo publishes npm + PyPI SDKs, pinning the publish workflows is the highest-value supply-chain hardening — worth a dedicated PR.

## Also recommended (repo settings)
Enable **CodeQL** code scanning (free on public repos) and **Dependabot security updates + alerts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)