### PR TITLE
ci: harden all workflows — SHA-pin actions, drop credentials, close injection paths

### DIFF
--- a/.github/actions/owlette-roost-deploy/action.yml
+++ b/.github/actions/owlette-roost-deploy/action.yml
@@ -48,13 +48,20 @@ runs:
   using: composite
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: '20'
 
     - name: Install owlette CLI
       shell: bash
-      run: npm install -g "@owlette/cli@${{ inputs['cli-version'] }}"
+      # The version comes in via env, not inline ${{ }} interpolation, so a
+      # crafted input can never expand into shell code (zizmor
+      # template-injection).
+      env:
+        CLI_VERSION: ${{ inputs['cli-version'] }}
+      # zizmor: ignore[adhoc-packages] — installing @owlette/cli at the
+      # requested dist-tag/version IS this composite action's purpose.
+      run: npm install -g "@owlette/cli@${CLI_VERSION}" # zizmor: ignore[adhoc-packages]
 
     - name: Verify API compatibility
       shell: bash

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -47,22 +47,31 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # full history so the VERSION + changelog commit that triggered
           # the tag are in the source tree for the build to reference.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: resolve version
         id: version
         shell: pwsh
+        # Context values come in via env, never inline ${{ }} interpolation, so
+        # a crafted tag or dispatch input cannot expand into PowerShell code
+        # (zizmor template-injection). The semver regex below stays the
+        # backstop that rejects anything that isn't plain X.Y.Z.
+        env:
+          REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          $ref = "${{ github.ref }}"
-          if ("${{ github.event_name }}" -eq "push" -and $ref -like "refs/tags/v*") {
+          $ref = $env:REF
+          if ($env:EVENT_NAME -eq "push" -and $ref -like "refs/tags/v*") {
             # trim leading refs/tags/v
             $v = $ref.Substring("refs/tags/v".Length)
-          } elseif ("${{ github.event.inputs.version }}" -ne "") {
-            $v = "${{ github.event.inputs.version }}"
+          } elseif ($env:INPUT_VERSION) {
+            $v = $env:INPUT_VERSION
           } else {
             $v = (Get-Content "agent/VERSION" -ErrorAction Stop).Trim()
           }
@@ -88,13 +97,17 @@ jobs:
           }
 
       - name: pin Python toolchain version
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: build installer
         id: build
-        shell: cmd
+        # zizmor: ignore[misfeature] — cmd is deliberate: this step drives
+        # build_installer_full.bat, and rewriting the driver shell in a
+        # release-critical hermetic SLSA build trades real regression risk for
+        # an analysis-only benefit. Context values still arrive via env.
+        shell: cmd # zizmor: ignore[misfeature]
         working-directory: agent
         env:
           OWLETTE_VERSION: ${{ steps.version.outputs.version }}
@@ -110,8 +123,10 @@ jobs:
       - name: compute base64-subjects for SLSA generator
         id: digest
         shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          $version = "${{ steps.version.outputs.version }}"
+          $version = $env:VERSION
           $fileName = "Owlette-Installer-v$version.exe"
           $path = "agent/build/installer_output/$fileName"
           if (!(Test-Path $path)) {
@@ -134,7 +149,7 @@ jobs:
           "subjects-b64=$subjectsB64" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: upload installer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: owlette-installer
           path: agent/build/installer_output/Owlette-Installer-v${{ steps.version.outputs.version }}.exe
@@ -154,7 +169,11 @@ jobs:
       id-token: write       # keyless signing via OIDC
       contents: write       # attach attestation to release
       actions: read         # reusable workflow metadata
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    # The SLSA builder MUST be referenced by semver tag — the trusted-builder
+    # verification model resolves the tag itself; pinning to a commit SHA makes
+    # slsa-verifier reject the provenance. This is the one deliberate
+    # exception to the pin-everything policy.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       # base64-encoded `sha256sum` line for the installer (built in the digest
       # step). The generator base64-decodes this, so it must NOT be raw hex.
@@ -175,13 +194,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: owlette-installer
           path: .
 
       - name: upload installer to release
-        uses: softprops/action-gh-release@v2
+        # zizmor: ignore[superfluous-actions] — kept over `gh release upload`
+        # because it CREATES the release when a bare tag push arrives without
+        # one; the gh equivalent errors out in that case.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2 zizmor: ignore[superfluous-actions]
         with:
           files: |
             Owlette-Installer-v${{ needs.build.outputs.version }}.exe
@@ -210,7 +232,7 @@ jobs:
           chmod +x /usr/local/bin/slsa-verifier
 
       - name: download installer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: owlette-installer
           path: .
@@ -227,9 +249,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: verify provenance
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           slsa-verifier verify-artifact \
-            "Owlette-Installer-v${{ needs.build.outputs.version }}.exe" \
+            "Owlette-Installer-v${VERSION}.exe" \
             --provenance-path owlette-installer.intoto.jsonl \
             --source-uri "github.com/${GITHUB_REPOSITORY}" \
             --source-tag "${GITHUB_REF_NAME}"

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -49,19 +49,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+          # Never restore a shared cache into a publish build — a poisoned
+          # cache entry written from a lower-privilege context must not be
+          # able to reach the published artifact (zizmor cache-poisoning).
+          package-manager-cache: false
 
       - name: Upgrade npm to a trusted-publishing-capable version
         # Trusted publishing requires npm >= 11.5.1; node 22 ships npm 10.x.
-        run: npm install -g npm@latest
+        # zizmor: ignore[adhoc-packages] — npm itself can't come from the
+        # lockfile; >=11.5.1 is required for OIDC trusted publishing.
+        run: npm install -g npm@latest # zizmor: ignore[adhoc-packages]
 
       - name: Install dependencies
         working-directory: cli

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,10 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: these jobs only read the repo.
+permissions:
+  contents: read
+
 jobs:
   playwright:
     name: run suite against firebase emulators
@@ -29,9 +33,11 @@ jobs:
     # <6 min wall-clock once caches warm.
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
           cache: npm
@@ -40,7 +46,7 @@ jobs:
       # Temurin JDK 21 for Firebase emulators (Firestore emulator is a Java
       # binary). The `java` on the stock Ubuntu runner is fine, but pinning
       # to JDK 21 matches the local-dev setup documented in context.md.
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           distribution: temurin
           java-version: '21'
@@ -59,7 +65,7 @@ jobs:
 
       - name: cache playwright browsers
         id: pw-cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -78,7 +84,9 @@ jobs:
       # wrapper guarantees teardown even on a crashed test run — critical
       # for CI where lingering emulator processes would block reruns.
       - name: install firebase-tools
-        run: npm i -g firebase-tools@13
+        # zizmor: ignore[adhoc-packages] — emulator runner CLI, major-pinned;
+        # not a dependency of the code under test.
+        run: npm i -g firebase-tools@13 # zizmor: ignore[adhoc-packages]
 
       - name: run e2e suite
         working-directory: web
@@ -97,7 +105,7 @@ jobs:
       # e2e/.output/; that whole tree is the post-mortem surface.
       - name: upload playwright report
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: web/e2e/.output/

--- a/.github/workflows/no-token-logs.yml
+++ b/.github/workflows/no-token-logs.yml
@@ -24,15 +24,21 @@ concurrency:
   group: no-token-logs-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: these jobs only read the repo.
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: scan for logged tokens
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
 

--- a/.github/workflows/node-sdk-publish.yml
+++ b/.github/workflows/node-sdk-publish.yml
@@ -44,19 +44,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+          # Never restore a shared cache into a publish build — a poisoned
+          # cache entry written from a lower-privilege context must not be
+          # able to reach the published artifact (zizmor cache-poisoning).
+          package-manager-cache: false
 
       - name: Upgrade npm to a trusted-publishing-capable version
         # Trusted publishing requires npm >= 11.5.1; node 22 ships npm 10.x.
-        run: npm install -g npm@latest
+        # zizmor: ignore[adhoc-packages] — npm itself can't come from the
+        # lockfile; >=11.5.1 is required for OIDC trusted publishing.
+        run: npm install -g npm@latest # zizmor: ignore[adhoc-packages]
 
       - name: Install dependencies
         working-directory: sdks/node

--- a/.github/workflows/openapi-validate.yml
+++ b/.github/workflows/openapi-validate.yml
@@ -18,15 +18,21 @@ concurrency:
   group: openapi-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: these jobs only read the repo.
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: validate spec against routes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/py-sdk-publish.yml
+++ b/.github/workflows/py-sdk-publish.yml
@@ -52,12 +52,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -118,13 +119,13 @@ jobs:
 
       - name: Publish to TestPyPI
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (v1.14.0)
         with:
           packages-dir: sdks/python/dist
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish to PyPI
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi') }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (v1.14.0)
         with:
           packages-dir: sdks/python/dist


### PR DESCRIPTION
## What
Burns down **all 48 zizmor alerts** in the Security tab. `zizmor --persona=regular .github/` on this branch: **No findings to report.**

- **24 actions SHA-pinned** to the commit of the exact version already in use (`# vX` comments kept, so Dependabot's `actions` group bumps SHA + comment together)
- **`persist-credentials: false`** on all 7 checkouts
- **Least-privilege `permissions: contents: read`** on e2e / no-token-logs / openapi-validate
- **Cache-poisoning fix**: setup-node v6 enables package-manager caching by default — the npm publish workflows now set `package-manager-cache: false` so a cache entry written from a lower-privilege context can never reach a published artifact
- **Template-injection fixes**: `build-installer.yml` (tag/dispatch-input/version expansion into PowerShell) and the `owlette-roost-deploy` composite action (`cli-version` into bash) now pass context via `env`

## Deliberate exceptions (inline `zizmor: ignore` + justification in-file)
- **SLSA builder stays `@v2.1.0` by tag** — the trusted-builder verification model requires tag refs; SHA pins make `slsa-verifier` reject the provenance
- **softprops/action-gh-release stays** (pinned) — it creates the release when a bare tag push has none; `gh release upload` alone errors there
- **`npm install -g npm@latest`** — npm ≥11.5.1 required for OIDC trusted publishing; can't come from a lockfile
- **`firebase-tools@13` / `@owlette/cli@<tag>`** — runner tooling / the composite action's entire purpose
- **`shell: cmd` in the installer build** — batch-file driver; rewriting the shell of a release-critical SLSA build trades regression risk for analysis-only benefit

## Behavior preserved
No trigger, permission grant (beyond narrowing), or publish logic changed. OIDC trusted publishing (`id-token: write`) untouched. Same versions, now immutable refs.

## Verification plan
PR checks exercise e2e / no-token-logs / openapi-validate / zizmor directly (their workflow files changed → path filters fire). The publish workflows can't run on PRs — after merge I'll dispatch **cli-publish** and **node-sdk-publish** with `dry_run: true` and **py-sdk-publish** with `target: dry-run` to prove the full publish path end-to-end without releasing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)