### PR TITLE
fix(cli): point readiness-docs test at the migrated Fumadocs CLI docs

### DIFF
--- a/cli/__tests__/commands/readiness-docs.test.ts
+++ b/cli/__tests__/commands/readiness-docs.test.ts
@@ -1,27 +1,35 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import path from 'path';
 
 const repoRoot = path.resolve(__dirname, '../../..');
+
+// The CLI docs live in the web app's Fumadocs tree (they were migrated there
+// from the old repo-root docs/cli/*.md). Glob the directory instead of
+// hard-listing pages so adding or renaming a reference page can never
+// silently drop it from these invariants again.
+const cliDocsDir = 'web/content/docs/cli';
 
 function readRepoFile(relativePath: string): string {
   return readFileSync(path.join(repoRoot, relativePath), 'utf-8');
 }
 
+function mdxFilesUnder(relativeDir: string): string[] {
+  const abs = path.join(repoRoot, relativeDir);
+  return readdirSync(abs, { recursive: true, encoding: 'utf-8' })
+    .filter((f) => f.endsWith('.mdx'))
+    .map((f) => path.join(relativeDir, f))
+    .sort();
+}
+
 describe('CLI readiness docs', () => {
-  const docs = [
-    'cli/README.md',
-    'docs/cli/overview.md',
-    'docs/cli/readiness.md',
-    'docs/cli/reference/chat.md',
-    'docs/cli/reference/deploy.md',
-    'docs/cli/reference/machine.md',
-    'docs/cli/reference/process.md',
-    'docs/cli/reference/roost.md',
-    'docs/cli/reference/user.md',
-    'docs/cli/reference/webhook.md',
-  ]
-    .map(readRepoFile)
-    .join('\n');
+  const docPaths = ['cli/README.md', ...mdxFilesUnder(cliDocsDir)];
+  const docs = docPaths.map(readRepoFile).join('\n');
+
+  it('actually found the docs set (guards against the tree moving again)', () => {
+    expect(docPaths).toContain(`${cliDocsDir}/overview.mdx`);
+    expect(docPaths).toContain(`${cliDocsDir}/readiness.mdx`);
+    expect(docPaths.length).toBeGreaterThan(5);
+  });
 
   it('does not point CLI readers at old implementation tracks', () => {
     const staleNeedles = [
@@ -38,12 +46,12 @@ describe('CLI readiness docs', () => {
 
   it('documents rollback as the registered top-level command', () => {
     expect(docs).not.toContain(['owlette roost', 'rollback'].join(' '));
-    expect(existsSync(path.join(repoRoot, 'docs/cli/reference/rollback.md'))).toBe(true);
-    expect(readRepoFile('docs/cli/readiness.md')).toContain('owlette rollback <roostId>');
+    expect(existsSync(path.join(repoRoot, `${cliDocsDir}/reference/rollback.mdx`))).toBe(true);
+    expect(readRepoFile(`${cliDocsDir}/readiness.mdx`)).toContain('owlette rollback <roostId>');
   });
 
   it('captures the only shipped CLI stub and the planned webhook noun', () => {
-    const readiness = readRepoFile('docs/cli/readiness.md');
+    const readiness = readRepoFile(`${cliDocsDir}/readiness.mdx`);
     expect(readiness).toContain('machine live-view');
     expect(readiness).toContain('public-api deferred: live-view-webrtc');
     expect(readiness).toContain('`owlette webhook` is not registered');


### PR DESCRIPTION
## What
Fixes the `cli-publish` **Test** gate, which has been silently broken since the CLI docs migrated from repo-root `docs/cli/*.md` to `web/content/docs/cli/*.mdx`. Surfaced by the first dry-run dispatch after #57's workflow hardening — the gate only runs on `cli-v*` tags, so nothing had exercised it since the migration.

- The suite now **globs `web/content/docs/cli/**/*.mdx`** instead of hard-listing pages, so adding/renaming a reference page can't silently drop it from the invariants
- Added a guard test that fails loudly if the docs tree ever moves again
- All content assertions unchanged — every needle verified present in the new files (`rollback.mdx` exists, `readiness.mdx` documents `owlette rollback <roostId>`, the live-view stub, and the unregistered webhook noun)

## Verified
`npm test` in `cli/`: **31/31 suites, 257 passed** (previously: readiness-docs failed to even load).

After merge I'll re-dispatch `cli-publish.yml` with `dry_run: true` to confirm the full publish pipeline end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)