### PR TITLE
web: admin user-management polish, collapsible sidebar, audit-target + hydration fixes

### DIFF
--- a/web/__tests__/lib/authorizedHandler.test.ts
+++ b/web/__tests__/lib/authorizedHandler.test.ts
@@ -544,6 +544,52 @@ describe('authorizedPlatformHandler', () => {
     expect(res.status).toBe(503);
     expect(handler).not.toHaveBeenCalled();
   });
+
+  it('records the platform sentinel as audit target when no targetIdParam is set', async () => {
+    const handler = makePlatformHandler(async () => NextResponse.json({ ok: true }));
+    const wrapped = authorizedPlatformHandler({ capability: 'GLOBAL_SETTINGS_WRITE' })(handler);
+
+    await wrapped(makeRequest('http://localhost/api/platform/security/kill-switch', 'POST'));
+    const allow = setCalls.find((c) => (c.payload as { outcome?: string }).outcome === 'allow');
+    expect((allow!.payload as { target?: { id?: string } }).target?.id).toBe('__platform__');
+  });
+
+  it('records the route param as audit target when targetIdParam is set', async () => {
+    const handler = makePlatformHandler(async () => NextResponse.json({ ok: true }));
+    const wrapped = authorizedPlatformHandler<{ uid: string }>({
+      capability: 'USER_DELETE',
+      targetKind: 'user',
+      targetIdParam: 'uid',
+    })(handler as Parameters<ReturnType<typeof authorizedPlatformHandler<{ uid: string }>>>[0]);
+
+    const res = await wrapped(makeRequest('http://localhost/api/users/uid_bob', 'DELETE'), {
+      params: Promise.resolve({ uid: 'uid_bob' }),
+    });
+    expect(res.status).toBe(200);
+    const allow = setCalls.find((c) => (c.payload as { outcome?: string }).outcome === 'allow');
+    expect((allow!.payload as { target?: { kind?: string; id?: string } }).target).toEqual({
+      kind: 'user',
+      id: 'uid_bob',
+    });
+  });
+
+  it('names the target on deny audits too, so blocked deletes are attributable', async () => {
+    userDoc = { exists: true, data: () => ({ role: 'admin', sites: [] }) };
+    const handler = makePlatformHandler(async () => NextResponse.json({ ok: true }));
+    const wrapped = authorizedPlatformHandler<{ uid: string }>({
+      capability: 'USER_DELETE',
+      targetKind: 'user',
+      targetIdParam: 'uid',
+    })(handler as Parameters<ReturnType<typeof authorizedPlatformHandler<{ uid: string }>>>[0]);
+
+    const res = await wrapped(makeRequest('http://localhost/api/users/uid_bob', 'DELETE'), {
+      params: Promise.resolve({ uid: 'uid_bob' }),
+    });
+    expect(res.status).toBe(403);
+    await new Promise((r) => setImmediate(r));
+    const deny = setCalls.find((c) => (c.payload as { outcome?: string }).outcome === 'deny');
+    expect((deny!.payload as { target?: { id?: string } }).target?.id).toBe('uid_bob');
+  });
 });
 
 /* -------------------------------------------------------------------------- */

--- a/web/app/admin/layout.tsx
+++ b/web/app/admin/layout.tsx
@@ -4,10 +4,11 @@ import { useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import RequireSuperadmin from '@/components/RequireSuperadmin';
-import { Users, Package, ArrowLeft, Menu, X, Settings, Mail, KeyRound, Webhook, Clock, Bell } from 'lucide-react';
+import { Users, Package, ArrowLeft, Menu, X, Settings, Mail, KeyRound, Webhook, Clock, Bell, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useDevicePrefFlag } from '@/hooks/useDevicePrefFlag';
 
 /**
  * Admin Layout
@@ -23,6 +24,12 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   const router = useRouter();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
+  // Desktop sidebar collapse (icon-only), persisted per device. Replaces the
+  // former viewport-driven lg/xl auto-collapse with an explicit user control so
+  // the width is predictable regardless of window size. Mobile (<lg) always
+  // uses the full-width drawer, so this only governs the lg+ static sidebar.
+  const { value: collapsed, setValue: setCollapsed } = useDevicePrefFlag('adminSidebarCollapsed', false);
+
   const navItems = [
     {
       name: 'installers',
@@ -37,7 +44,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
       description: 'manage software catalog',
     },
     {
-      name: 'user management',
+      name: 'users',
       href: '/admin/users',
       icon: Users,
       description: 'manage user roles and permissions',
@@ -92,6 +99,28 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     router.push(backPath);
   };
 
+  // Icon-only collapse control, floated in the header corner when expanded.
+  // (Expanding is handled by the owl-eye logo itself when collapsed — see the
+  // header block below — so this only ever collapses.)
+  const renderCollapseButton = () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setCollapsed(true)}
+          aria-label="collapse sidebar"
+          className="shrink-0 text-muted-foreground hover:text-foreground! hover:bg-accent! cursor-pointer"
+        >
+          <PanelLeftClose className="h-4 w-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        <p>collapse sidebar</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+
   return (
     <RequireSuperadmin>
       <TooltipProvider delayDuration={100}>
@@ -120,13 +149,15 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
 
         {/* Sidebar Navigation */}
         <aside className={`
-          w-64 lg:w-20 xl:w-64 bg-card border-r border-border flex flex-col
+          w-64 ${collapsed ? 'lg:w-20' : 'lg:w-64'} bg-card border-r border-border flex flex-col
           fixed lg:static inset-y-0 left-0 z-40
           transform transition-all duration-200 ease-in-out
           ${mobileMenuOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
         `}>
-          {/* Header */}
-          <div className="p-6 lg:p-3 xl:p-6 border-b border-border">
+          {/* Header — vertical padding is held constant across states (only the
+              horizontal shrinks when collapsed) so the logo doesn't shift up or
+              down as the rail folds. */}
+          <div className={`p-6 ${collapsed ? 'lg:px-3 lg:py-6' : 'lg:p-6'} border-b border-border`}>
             {/* Mobile Header */}
             <div className="lg:hidden mb-4">
               <div className="flex items-center justify-between mb-2">
@@ -142,15 +173,54 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
               <p className="text-sm text-muted-foreground">system management</p>
             </div>
 
-            {/* Desktop/Tablet Header */}
-            <div className="hidden lg:flex items-center gap-3 mb-4 lg:justify-center xl:justify-start">
-              <div className="flex-shrink-0">
-                <Image src="/owlette-icon.png" alt="Owlette" width={40} height={40} />
-              </div>
-              <div className="hidden xl:block">
-                <h1 className="text-xl font-bold text-foreground">admin panel</h1>
-                <p className="text-xs text-muted-foreground">system management</p>
-              </div>
+            {/* Desktop/Tablet Header — fixed row height + constant logo size in
+                both states, so the owl eye lands at the exact same y whether the
+                rail is expanded or collapsed (no vertical jump on toggle). */}
+            <div className={`hidden lg:flex items-center h-11 mb-4 ${collapsed ? 'justify-center' : 'relative gap-2'}`}>
+              {collapsed ? (
+                /* Collapsed: the owl-eye logo doubles as the expand control —
+                   at rest it's the logo, on hover/focus it swaps to an expand
+                   icon. Folding the two together saves a row on the icon rail.
+                   Desktop only; mobile uses the drawer's own close (X). */
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => setCollapsed(false)}
+                      aria-label="expand sidebar"
+                      className="group relative flex items-center justify-center h-10 w-10 rounded-lg transition-colors hover:bg-accent! focus-visible:bg-accent! outline-none cursor-pointer"
+                    >
+                      <Image
+                        src="/owlette-icon.png"
+                        alt="Owlette"
+                        width={36}
+                        height={36}
+                        className="transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0"
+                      />
+                      <PanelLeftOpen className="absolute h-5 w-5 text-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    <p>expand sidebar</p>
+                  </TooltipContent>
+                </Tooltip>
+              ) : (
+                <>
+                  <div className="flex-shrink-0">
+                    <Image src="/owlette-icon.png" alt="Owlette" width={36} height={36} />
+                  </div>
+                  <div className="block pr-8">
+                    <h1 className="text-xl font-bold text-foreground">admin panel</h1>
+                    <p className="text-xs text-muted-foreground">system management</p>
+                  </div>
+                  {/* Collapse control — icon-only, floated at the row's right
+                      edge, vertically centered on the logo; the title's pr-8
+                      keeps text clear of it. */}
+                  <div className="absolute right-0 top-1/2 -translate-y-1/2">
+                    {renderCollapseButton()}
+                  </div>
+                </>
+              )}
             </div>
 
             {/* Back Button */}
@@ -160,20 +230,20 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                   variant="outline"
                   size="sm"
                   onClick={handleBack}
-                  className="w-full border-border bg-background text-foreground hover:bg-accent! hover:text-foreground! cursor-pointer lg:px-2 xl:px-3"
+                  className={`w-full border-border bg-background text-foreground hover:bg-accent! hover:text-foreground! cursor-pointer ${collapsed ? 'lg:px-2' : 'lg:px-3'}`}
                 >
-                  <ArrowLeft className="h-4 w-4 lg:mr-0 xl:mr-2" />
-                  <span className="lg:hidden xl:inline">{backLabel}</span>
+                  <ArrowLeft className={`h-4 w-4 ${collapsed ? 'lg:mr-0' : 'lg:mr-2'}`} />
+                  <span className={collapsed ? 'inline lg:hidden' : 'inline'}>{backLabel}</span>
                 </Button>
               </TooltipTrigger>
-              <TooltipContent side="right" className="hidden lg:block xl:hidden">
+              <TooltipContent side="right" className={collapsed ? 'hidden lg:block' : 'hidden'}>
                 <p>{backLabel}</p>
               </TooltipContent>
             </Tooltip>
           </div>
 
           {/* Navigation Links */}
-          <nav className="flex-1 p-4 lg:p-2 xl:p-4">
+          <nav className={`flex-1 p-4 ${collapsed ? 'lg:p-2' : 'lg:p-4'}`}>
             {navItems.map((item) => {
               const isActive = pathname === item.href;
               const Icon = item.icon;
@@ -184,7 +254,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                     <Link href={item.href} onClick={() => setMobileMenuOpen(false)}>
                       <div
                         className={`
-                          flex items-start gap-3 p-3 lg:p-2 lg:justify-center xl:justify-start xl:p-3 rounded-lg cursor-pointer transition-colors mb-2
+                          flex items-start gap-3 p-3 ${collapsed ? 'lg:p-2 lg:justify-center' : 'lg:p-3 lg:justify-start'} rounded-lg cursor-pointer transition-colors mb-2
                           ${
                             isActive
                               ? 'bg-accent-cyan/15 text-accent-cyan border border-accent-cyan/30'
@@ -193,7 +263,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                         `}
                       >
                         <Icon className="h-5 w-5 mt-0.5 flex-shrink-0" />
-                        <div className="lg:hidden xl:block">
+                        <div className={`block ${collapsed ? 'lg:hidden' : 'lg:block'}`}>
                           <p className="font-medium text-sm">{item.name}</p>
                           <p
                             className={`text-xs mt-0.5 ${
@@ -206,7 +276,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                       </div>
                     </Link>
                   </TooltipTrigger>
-                  <TooltipContent side="right" className="hidden lg:block xl:hidden">
+                  <TooltipContent side="right" className={collapsed ? 'hidden lg:block' : 'hidden'}>
                     <p className="font-medium">{item.name}</p>
                     <p className="text-xs text-muted-foreground">{item.description}</p>
                   </TooltipContent>

--- a/web/app/admin/users/page.tsx
+++ b/web/app/admin/users/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useUserManagement, type UserRole } from '@/hooks/useUserManagement';
+import { useDevicePrefFlag } from '@/hooks/useDevicePrefFlag';
 import type { FirestoreTs } from '@/hooks/useFirestore';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import { Users, Shield, ShieldAlert, Crown, Loader2, Settings, MoreVertical, UserCog, Trash2 } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { toast } from 'sonner';
@@ -69,6 +72,45 @@ interface UserActivity {
 }
 
 /**
+ * Audit target id recorded by platform routes that act on the platform itself
+ * rather than one addressable resource. Admin-delete rows written before
+ * `/api/users/{uid}` started passing `targetIdParam` carry this instead of the
+ * deleted uid, so the feed shows "user not recorded" for them.
+ */
+const PLATFORM_TARGET_ID = '__platform__';
+
+/** Per-device pref field on `users/{uid}/devicePrefs/global`. */
+const SHOW_DELETED_USERS_PREF = 'adminShowDeletedUsers';
+
+/**
+ * Compact tally chip. Lives in the page header (right of the title) rather
+ * than in a full-width card row so the users table gets the vertical space.
+ */
+function StatChip({
+  icon: Icon,
+  iconBg,
+  count,
+  label,
+}: {
+  icon: typeof Users;
+  iconBg: string;
+  count: number;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2">
+      <div className={`p-1.5 rounded-md ${iconBg}`}>
+        <Icon className="h-4 w-4 text-foreground" />
+      </div>
+      <div className="leading-tight">
+        <p className="text-lg font-bold text-foreground">{count}</p>
+        <p className="text-xs text-muted-foreground whitespace-nowrap">{label}</p>
+      </div>
+    </div>
+  );
+}
+
+/**
  * User Management Page
  *
  * Admin-only page for managing user roles and permissions.
@@ -89,9 +131,35 @@ export default function UserManagementPage() {
   const [userToDelete, setUserToDelete] = useState<{ uid: string; email: string } | null>(null);
   const [userToChangeRole, setUserToChangeRole] = useState<{ uid: string; email: string; currentRole: UserRole; newRole: UserRole } | null>(null);
   const [deletions, setDeletions] = useState<DeletionView[]>([]);
+  const [deletionsLoading, setDeletionsLoading] = useState(false);
   const [activity, setActivity] = useState<Record<string, UserActivity>>({});
 
+  // Show/hide deleted accounts in the users table, persisted per device so the
+  // choice survives reloads. Defaults to shown — hiding them is opt-in, since
+  // silently dropping rows would be a surprise for anyone who never toggles it.
+  const { value: showDeletedUsers, setValue: setShowDeletedUsers } = useDevicePrefFlag(
+    SHOW_DELETED_USERS_PREF,
+    true,
+  );
+
   const counts = getUserCounts();
+
+  // The tally chips already count active accounts only, so hiding deleted rows
+  // keeps the table and the chips telling the same story.
+  const visibleUsers = useMemo(
+    () => (showDeletedUsers ? users : users.filter((u) => u.deletedAt == null)),
+    [users, showDeletedUsers],
+  );
+
+  // uid -> display label, so audit rows can name people instead of raw uids.
+  // Soft-deleted users stay in `users`, so deleted accounts still resolve.
+  const userLabels = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const u of users) {
+      map[u.uid] = u.email || u.displayName || u.uid;
+    }
+    return map;
+  }, [users]);
 
   // Fetch the account-deletion audit feed once. Non-fatal: on error we log and
   // leave `deletions` empty so the panel renders its empty state.
@@ -99,6 +167,7 @@ export default function UserManagementPage() {
     let cancelled = false;
 
     (async () => {
+      setDeletionsLoading(true);
       try {
         const response = await fetch('/api/users/deletions');
         if (!response.ok) {
@@ -110,6 +179,8 @@ export default function UserManagementPage() {
         setDeletions(Array.isArray(body.deletions) ? body.deletions : []);
       } catch (err) {
         console.error('Error fetching account deletions:', err);
+      } finally {
+        if (!cancelled) setDeletionsLoading(false);
       }
     })();
 
@@ -248,62 +319,22 @@ export default function UserManagementPage() {
   return (
     <div className="p-8">
       <div className="max-w-screen-2xl mx-auto">
-        {/* Header */}
-        <div className="mb-8">
-        <h1 className="text-3xl font-bold text-foreground mb-2">user management</h1>
-        <p className="text-muted-foreground">manage user roles and permissions</p>
-      </div>
+        {/* Header — tally chips sit beside the title (not in a full-width card
+            row) so the users table keeps the vertical space. Chips are ordered
+            by ascending privilege, so the platform tier sits last. */}
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-x-6 gap-y-4">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground mb-2">user management</h1>
+            <p className="text-muted-foreground">manage user roles and permissions</p>
+          </div>
 
-      {/* Stats Cards — ordered by ascending privilege so the platform tier sits last. */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-8">
-        <div className="bg-card border border-border rounded-lg p-6">
-          <div className="flex items-center gap-3">
-            <div className="p-3 bg-accent-cyan rounded-lg">
-              <Users className="h-6 w-6 text-foreground" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-foreground">{counts.total}</p>
-              <p className="text-sm text-muted-foreground">total users</p>
-            </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <StatChip icon={Users} iconBg="bg-accent-cyan" count={counts.total} label="total users" />
+            <StatChip icon={Users} iconBg="bg-muted" count={counts.members} label="members" />
+            <StatChip icon={Shield} iconBg="bg-green-600" count={counts.admins} label="site admins" />
+            <StatChip icon={Crown} iconBg="bg-red-600" count={counts.superadmins} label="superadmins" />
           </div>
         </div>
-
-        <div className="bg-card border border-border rounded-lg p-6">
-          <div className="flex items-center gap-3">
-            <div className="p-3 bg-muted rounded-lg">
-              <Users className="h-6 w-6 text-foreground" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-foreground">{counts.members}</p>
-              <p className="text-sm text-muted-foreground">members</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-card border border-border rounded-lg p-6">
-          <div className="flex items-center gap-3">
-            <div className="p-3 bg-green-600 rounded-lg">
-              <Shield className="h-6 w-6 text-foreground" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-foreground">{counts.admins}</p>
-              <p className="text-sm text-muted-foreground">site admins</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-card border border-border rounded-lg p-6">
-          <div className="flex items-center gap-3">
-            <div className="p-3 bg-red-600 rounded-lg">
-              <Crown className="h-6 w-6 text-foreground" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-foreground">{counts.superadmins}</p>
-              <p className="text-sm text-muted-foreground">superadmins</p>
-            </div>
-          </div>
-        </div>
-      </div>
 
       {/* Error State */}
       {error && (
@@ -323,6 +354,24 @@ export default function UserManagementPage() {
       {/* Users Table */}
       {!loading && !error && (
         <div className="bg-card border border-border rounded-lg overflow-hidden">
+          {/* Table toolbar — deleted accounts are soft-deleted and stay listed
+              for auditability, so they're filterable rather than dropped. */}
+          <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-2 px-4 py-3 border-b border-border">
+            {!showDeletedUsers && counts.deleted > 0 && (
+              <span className="text-xs text-muted-foreground mr-auto">
+                {counts.deleted} deleted account{counts.deleted === 1 ? '' : 's'} hidden
+              </span>
+            )}
+            <Label htmlFor="show-deleted-users" className="text-sm text-muted-foreground cursor-pointer">
+              show deleted accounts
+            </Label>
+            <Switch
+              id="show-deleted-users"
+              checked={showDeletedUsers}
+              onCheckedChange={setShowDeletedUsers}
+              aria-label="show deleted accounts"
+            />
+          </div>
           <table className="w-full">
             <thead>
               <tr className="border-b border-border bg-background/50">
@@ -335,14 +384,14 @@ export default function UserManagementPage() {
               </tr>
             </thead>
             <tbody>
-              {users.length === 0 ? (
+              {visibleUsers.length === 0 ? (
                 <tr>
                   <td colSpan={6} className="p-8 text-center text-muted-foreground">
-                    no users found
+                    {users.length === 0 ? 'no users found' : 'no active users — every account here is deleted'}
                   </td>
                 </tr>
               ) : (
-                users.map((user) => {
+                visibleUsers.map((user) => {
                   const isDeleted = user.deletedAt != null;
                   return (
                   <tr
@@ -535,26 +584,76 @@ export default function UserManagementPage() {
       {/* Account-deletions audit feed — self-deletes + admin-deletes, newest-first. */}
       {!loading && !error && (
         <div className="mt-6 bg-card border border-border rounded-lg p-6">
-          <h2 className="text-lg font-semibold text-foreground mb-4">account deletions</h2>
-          {deletions.length === 0 ? (
-            <p className="text-sm text-muted-foreground italic">no recent deletions</p>
+          <h2 className="text-lg font-semibold text-foreground">account deletions</h2>
+          <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
+            a record of accounts that were removed — anyone can delete their own account from
+            settings, and superadmins can delete others from this page. each entry shows who was
+            removed, who removed them, and what the cascade cleaned up.
+          </p>
+
+          {deletionsLoading && deletions.length === 0 ? (
+            <div className="flex items-center gap-2 mt-4 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              loading deletions...
+            </div>
+          ) : deletions.length === 0 ? (
+            <p className="text-sm text-muted-foreground italic mt-4">no accounts have been deleted</p>
           ) : (
-            <ul className="divide-y divide-border">
-              {deletions.map((d) => (
-                <li key={d.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-3 text-sm">
-                  <Badge className="bg-secondary border border-border text-muted-foreground text-xs">
-                    {d.capability === 'USER_SELF_DELETE' ? 'self-delete' : 'admin-delete'}
-                  </Badge>
-                  <span className="font-mono text-foreground">{d.uid ?? 'unknown'}</span>
-                  <span className="text-muted-foreground">{formatDate(d.timestamp)}</span>
-                  <span className="text-muted-foreground">{d.outcome}</span>
-                  {d.counts && (
-                    <span className="text-muted-foreground">
-                      {d.counts.sites ?? 0} site{d.counts.sites !== 1 ? 's' : ''} · {d.counts.machines ?? 0} machine{d.counts.machines !== 1 ? 's' : ''}
-                    </span>
-                  )}
-                </li>
-              ))}
+            <ul className="divide-y divide-border mt-4">
+              {deletions.map((d) => {
+                const selfDelete = d.capability === 'USER_SELF_DELETE';
+                // Legacy admin-delete rows recorded the platform sentinel rather
+                // than the deleted uid — surface that instead of the raw token.
+                const targetUid = d.uid && d.uid !== PLATFORM_TARGET_ID ? d.uid : null;
+                const targetLabel = targetUid ? userLabels[targetUid] ?? targetUid : null;
+                const actorLabel = d.actorUid ? userLabels[d.actorUid] ?? d.actorUid : 'an unknown actor';
+                const blocked = d.outcome !== 'allow';
+
+                const detail = [
+                  blocked
+                    ? selfDelete
+                      ? 'requested their own deletion'
+                      : `requested by ${actorLabel}`
+                    : selfDelete
+                      ? 'deleted their own account'
+                      : `deleted by ${actorLabel}`,
+                  formatDate(d.timestamp),
+                  ...(d.counts && !blocked
+                    ? [`removed ${d.counts.sites ?? 0} site${d.counts.sites === 1 ? '' : 's'}, ${d.counts.machines ?? 0} machine${d.counts.machines === 1 ? '' : 's'}`]
+                    : []),
+                ].join(' · ');
+
+                return (
+                  <li key={d.id} className="flex flex-wrap items-center gap-x-2 gap-y-1 py-3 text-sm">
+                    <Badge className="bg-secondary border border-border text-muted-foreground text-xs">
+                      {selfDelete ? 'self-delete' : 'admin-delete'}
+                    </Badge>
+                    {targetLabel ? (
+                      <span className="text-foreground font-medium">{targetLabel}</span>
+                    ) : (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="text-muted-foreground italic">account not recorded</span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p className="max-w-xs">
+                            this entry predates the fix that records which account was deleted; only
+                            the actor and timestamp were logged.
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                    {blocked && (
+                      <Badge className="bg-red-950/40 border border-red-900/60 text-red-300 text-xs">
+                        {d.outcome === 'deny'
+                          ? `blocked${d.denyReason ? ` · ${d.denyReason.replace(/_/g, ' ')}` : ''}`
+                          : 'failed'}
+                      </Badge>
+                    )}
+                    <span className="text-muted-foreground">{detail}</span>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </div>

--- a/web/app/api/users/[uid]/route.ts
+++ b/web/app/api/users/[uid]/route.ts
@@ -121,6 +121,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<Ro
 export const DELETE = authorizedPlatformHandler<RouteParams>({
   capability: Capability.USER_DELETE,
   targetKind: 'user',
+  // Record the deleted uid as the audit target — the account-deletions feed
+  // (`GET /api/users/deletions`) reads `target.id` to name who was removed.
+  targetIdParam: 'uid',
   apiKeyScope: { resource: 'user', permission: 'admin' },
 })(async (request: NextRequest, ctx: PlatformHandlerContext, routeContext) => {
   try {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -12,7 +12,7 @@ import { PRODUCT_JSONLD } from '@/lib/product-facts';
 // Lazy-load below-fold sections to reduce initial JS bundle
 // Note: ValuePropSection stays static because it contains the LCP image (dashboard.png)
 const UseCaseSection = dynamic(() => import('@/components/landing/UseCaseSection').then(m => ({ default: m.UseCaseSection })));
-const DisplaySection = dynamic<{ nonce?: string }>(() => import('@/components/landing/DisplaySection').then(m => ({ default: m.DisplaySection })));
+const DisplaySection = dynamic(() => import('@/components/landing/DisplaySection').then(m => ({ default: m.DisplaySection })));
 const DeveloperSection = dynamic(() => import('@/components/landing/DeveloperSection').then(m => ({ default: m.DeveloperSection })));
 const FeatureGrid = dynamic(() => import('@/components/landing/FeatureGrid').then(m => ({ default: m.FeatureGrid })));
 const ProofStrip = dynamic(() => import('@/components/landing/ProofStrip').then(m => ({ default: m.ProofStrip })));
@@ -27,9 +27,16 @@ export default async function LandingPage() {
 
   return (
     <div className="min-h-screen relative">
+      {/* suppressHydrationWarning: browsers blank the `nonce` content attribute
+          once the element is inserted (the value moves to the `.nonce` IDL
+          property, so CSS attribute selectors can't exfiltrate it). React's
+          hydration diff reads the attribute, sees "", and reports a mismatch
+          against the nonce it rendered — a false positive, since the browser
+          has already applied the real value. */}
       <script
         nonce={nonce}
         type="application/ld+json"
+        suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       {/* Page-wide dot grid background */}
@@ -39,7 +46,7 @@ export default async function LandingPage() {
         <HeroSection />
         <ValuePropSection />
         <UseCaseSection />
-        <DisplaySection nonce={nonce} />
+        <DisplaySection />
         <DeveloperSection />
         <FeatureGrid />
         <PricingSection />

--- a/web/components/landing/DisplaySection.tsx
+++ b/web/components/landing/DisplaySection.tsx
@@ -1,11 +1,7 @@
 import Link from 'next/link';
 import { ArrowRight, Check, Eye, Layers, RotateCcw, AlertTriangle } from 'lucide-react';
 
-interface DisplaySectionProps {
-  nonce?: string;
-}
-
-export function DisplaySection({ nonce }: DisplaySectionProps) {
+export function DisplaySection() {
   return (
     <section className="py-16 sm:py-24 px-4 sm:px-6 relative">
       <div className="max-w-5xl mx-auto">
@@ -211,7 +207,11 @@ export function DisplaySection({ nonce }: DisplaySectionProps) {
           glowing slightly; otherwise it sits at rest. The drift frame's
           displaced monitors (2, 3) animate into their off-baseline position
           during the drift phase only. */}
-      <style nonce={nonce}>{`
+      {/* No nonce: the CSP grants styles via `style-src 'self' 'unsafe-inline'`
+          with no style nonce at all (see proxy.ts), so a nonce here would be
+          inert — and browsers blank the `nonce` content attribute on insert,
+          which made React's hydration diff report a false mismatch. */}
+      <style>{`
         @keyframes display-section-pulse {
           0%, 100% { opacity: 1; }
           50%      { opacity: 0.35; }

--- a/web/e2e/specs/access-control/user-mgmt.spec.ts
+++ b/web/e2e/specs/access-control/user-mgmt.spec.ts
@@ -28,7 +28,7 @@ test.describe('/admin/users — stats row', () => {
 
     // Confirm their visual order in the DOM matches ascending-privilege.
     const texts = await page
-      .locator('p.text-sm.text-muted-foreground')
+      .locator('p.text-xs.text-muted-foreground')
       .filter({ hasText: /total users|members|site admins|superadmins/ })
       .allTextContents();
     expect(texts).toEqual(labels);
@@ -37,15 +37,15 @@ test.describe('/admin/users — stats row', () => {
   test('counts reflect seeded fleet (1 super, 1 admin, 1 member)', async ({ page }) => {
     await page.goto('/admin/users');
 
-    // Each stat card is a `.bg-card.rounded-lg` wrapping the count (p.text-2xl)
-    // and label (p.text-sm). Find the card by its label, then read the count.
+    // Each stat chip is a `.bg-card.rounded-lg` wrapping the count (p.text-lg)
+    // and label (p.text-xs). Find the chip by its label, then read the count.
     const card = (label: string) =>
       page.locator('div.bg-card.rounded-lg').filter({ hasText: label });
 
-    await expect(card('total users').locator('p.text-2xl')).toHaveText('3');
-    await expect(card('members').locator('p.text-2xl')).toHaveText('1');
-    await expect(card('site admins').locator('p.text-2xl')).toHaveText('1');
-    await expect(card('superadmins').locator('p.text-2xl')).toHaveText('1');
+    await expect(card('total users').locator('p.text-lg')).toHaveText('3');
+    await expect(card('members').locator('p.text-lg')).toHaveText('1');
+    await expect(card('site admins').locator('p.text-lg')).toHaveText('1');
+    await expect(card('superadmins').locator('p.text-lg')).toHaveText('1');
   });
 });
 

--- a/web/hooks/useDevicePrefFlag.ts
+++ b/web/hooks/useDevicePrefFlag.ts
@@ -1,0 +1,107 @@
+'use client';
+
+/**
+ * Per-device persistence for a single boolean UI preference (panel shown /
+ * hidden, section collapsed, etc.).
+ *
+ * Stored on the shared per-device prefs doc — `users/{uid}/devicePrefs/global`,
+ * the same doc `useDevicePrefs` and `useCortexSidebarPrefs` write to — under
+ * the caller-supplied `field`. Hydrated once on mount; afterwards local state
+ * is the source of truth and writes are debounced.
+ *
+ * `ready` stays false until hydration settles so callers can hold off on
+ * rendering (or fetching) until the stored value is known, instead of flashing
+ * the default and then snapping to the persisted value.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { useAuth } from '@/contexts/AuthContext';
+import { db } from '@/lib/firebase';
+
+const DEBOUNCE_MS = 400;
+
+export interface DevicePrefFlag {
+  value: boolean;
+  setValue: (next: boolean) => void;
+  /** False until the stored value has been read (or determined absent). */
+  ready: boolean;
+}
+
+export function useDevicePrefFlag(field: string, defaultValue: boolean): DevicePrefFlag {
+  const { user } = useAuth();
+  const uid = user?.uid ?? null;
+
+  const [value, setValueState] = useState(defaultValue);
+  const [ready, setReady] = useState(false);
+
+  const uidRef = useRef<string | null>(uid);
+  const fieldRef = useRef(field);
+  useEffect(() => { uidRef.current = uid; }, [uid]);
+  useEffect(() => { fieldRef.current = field; }, [field]);
+
+  const pendingRef = useRef<boolean | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flush = useCallback(() => {
+    const currentUid = uidRef.current;
+    const next = pendingRef.current;
+    pendingRef.current = null;
+    if (!db || !currentUid || next === null) return;
+    setDoc(doc(db, 'users', currentUid, 'devicePrefs', 'global'), { [fieldRef.current]: next }, { merge: true })
+      .catch((err) => console.error(`Failed to persist device pref "${fieldRef.current}":`, err));
+  }, []);
+
+  // Hydrate once per uid. setState lives in the async callback (not the
+  // synchronous effect body) so it doesn't trip the cascading-render lint rule.
+  useEffect(() => {
+    if (!db || !uid) return;
+    let cancelled = false;
+    getDoc(doc(db, 'users', uid, 'devicePrefs', 'global'))
+      .then((snap) => {
+        if (cancelled) return;
+        const stored = snap.exists() ? (snap.data() as Record<string, unknown>)[field] : undefined;
+        if (typeof stored === 'boolean') setValueState(stored);
+        setReady(true);
+      })
+      .catch((err) => {
+        console.error(`Failed to read device pref "${field}":`, err);
+        if (!cancelled) setReady(true);
+      });
+    return () => {
+      cancelled = true;
+      // A different sign-in must re-hydrate before its stored value is trusted.
+      setReady(false);
+      setValueState(defaultValue);
+    };
+  }, [uid, field, defaultValue]);
+
+  // Flush any pending write on unmount so a toggle right before navigation sticks.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+        flush();
+      }
+    };
+  }, [flush]);
+
+  const setValue = useCallback(
+    (next: boolean) => {
+      setValueState(next);
+      if (!db || !uidRef.current) return;
+      pendingRef.current = next;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        flush();
+      }, DEBOUNCE_MS);
+    },
+    [flush],
+  );
+
+  // Nothing to hydrate when signed out (or firestore is unavailable), so the
+  // default value is already the final answer — report ready immediately.
+  return { value, setValue, ready: ready || !db || !uid };
+}

--- a/web/lib/authorizedHandler.server.ts
+++ b/web/lib/authorizedHandler.server.ts
@@ -146,6 +146,13 @@ export interface PlatformHandlerOptions {
   capability: Capability;
   targetKind?: AuditTargetKind;
   /**
+   * Dynamic route param to use as the audit target id. Omit for routes that
+   * act on the platform itself — those record `__platform__`. Routes that
+   * mutate one addressable resource (e.g. `/api/users/{uid}`) MUST pass their
+   * param so the audit row names the resource that changed.
+   */
+  targetIdParam?: string;
+  /**
    * API-key scope that callers must hold to invoke this route. Sessions
    * and id-token auth bypass scope (consistent with `requireScope`); only
    * api-key callers are gated. Defaults to `{ resource: 'user', permission: 'admin' }`
@@ -342,6 +349,12 @@ function platformDenyAudit(entry: AuditEntryInput): void {
 // Firestore reserves document ids matching `__.*__`; platform routes still
 // need a stable bucket for rate-limit counters, so use a non-reserved id.
 const PLATFORM_RATE_LIMIT_SITE_ID = 'platform_global';
+
+// Audit `target.id` for platform routes that act on the platform itself
+// (global settings, kill-switch) rather than a single addressable resource.
+// Routes that DO act on one resource pass `targetIdParam` so the audit row
+// names it — readers (e.g. the account-deletions feed) rely on that id.
+const PLATFORM_TARGET_ID = '__platform__';
 
 function auditActorRoleLabel(actor: AuditEntryInput['actor']): string {
   if (actor.type === 'system') return `system:${actor.name}`;
@@ -661,6 +674,16 @@ export function authorizedPlatformHandler<TParams extends Record<string, string 
     ): Promise<NextResponse> {
       const correlationId = generateCorrelationId();
       const targetKind: AuditTargetKind = options.targetKind ?? 'site';
+      // Resolved once, up front, so every audit row this wrapper writes
+      // (deny, allow, error) names the same target. Falls back to the
+      // platform sentinel when the route has no addressable resource.
+      const targetId = options.targetIdParam
+        ? (await extractRouteParam(
+            (routeContext?.params ?? Promise.resolve({} as TParams)) as Promise<Record<string, string | undefined>>,
+            options.targetIdParam,
+          )) ?? PLATFORM_TARGET_ID
+        : PLATFORM_TARGET_ID;
+      const auditTarget = { kind: targetKind, id: targetId } as AuditTarget;
 
       let auth: ResolvedAuth;
       try {
@@ -690,7 +713,7 @@ export function authorizedPlatformHandler<TParams extends Record<string, string 
           correlationId,
           actor,
           capability: options.capability,
-          target: { kind: targetKind, id: '__platform__' } as AuditTarget,
+          target: auditTarget,
           outcome: 'deny',
           denyReason: 'role_insufficient',
           metadata: { route: request.nextUrl.pathname, method: request.method },
@@ -710,7 +733,7 @@ export function authorizedPlatformHandler<TParams extends Record<string, string 
             correlationId,
             actor,
             capability: options.capability,
-            target: { kind: targetKind, id: '__platform__' } as AuditTarget,
+            target: auditTarget,
             outcome: 'deny',
             denyReason: 'scope_insufficient',
             metadata: { route: request.nextUrl.pathname, method: request.method },
@@ -730,7 +753,7 @@ export function authorizedPlatformHandler<TParams extends Record<string, string 
             correlationId,
             actor,
             capability: options.capability,
-            target: { kind: targetKind, id: '__platform__' } as AuditTarget,
+            target: auditTarget,
             outcome: 'deny',
             denyReason: 'capability_missing',
             metadata: { route: request.nextUrl.pathname, method: request.method },
@@ -755,7 +778,7 @@ export function authorizedPlatformHandler<TParams extends Record<string, string 
             correlationId,
             actor,
             capability: options.capability,
-            target: { kind: targetKind, id: '__platform__' } as AuditTarget,
+            target: auditTarget,
             outcome: 'deny',
             denyReason: 'rate_limited',
             metadata: {
@@ -783,7 +806,7 @@ export function authorizedPlatformHandler<TParams extends Record<string, string 
           correlationId,
           actor,
           capability: options.capability,
-          target: { kind: targetKind, id: '__platform__' } as AuditTarget,
+          target: auditTarget,
           outcome: 'allow',
           metadata: bypassMeta,
           enforcementBypassed: Boolean(enforcementBypassed) || rateLimitBypassed,
@@ -812,7 +835,7 @@ export function authorizedPlatformHandler<TParams extends Record<string, string 
           correlationId,
           actor,
           capability: options.capability,
-          target: { kind: targetKind, id: '__platform__' } as AuditTarget,
+          target: auditTarget,
           outcome: 'error',
           errorCode: err instanceof Error ? err.name : 'handler_error',
           metadata: { route: request.nextUrl.pathname, method: request.method },


### PR DESCRIPTION
Promotes the current `dev` to production (owlette.app). Deploys under the existing **2.12.19** (no version bump — UX/bugfix web changes only).

## Commits
- **fix(web): record deleted uid in platform audit target** — `authorizedPlatformHandler` hardcoded `target.id = '__platform__'` for every audit row, so admin-deletes never recorded *which* account was removed. Adds an optional `targetIdParam` (mirroring `authorizedSiteHandler`); opts the user-delete route in. Additive — the `/api/users/deletions` feed already exists on prod.
- **fix(web): resolve landing-page hydration nonce mismatch** — browsers blank the `nonce` content attribute after insert; React's hydration diff flagged it on the JSON-LD script + DisplaySection `<style>`. Drops the inert style nonce and adds `suppressHydrationWarning` to the script (nonce retained there).
- **feat(web): admin user-management + collapsible sidebar polish** — sidebar nav "user management" → "users"; per-device collapse toggle (owl-eye logo doubles as the expand control when collapsed, no vertical jump between states); tally cards → header chips; per-device "show deleted accounts" table filter; plain-language account-deletions feed. New `useDevicePrefFlag` hook (Firestore devicePrefs, rule already on main).

## Safety
- Merge is **conflict-free** — verified via `merge-tree` dry-run; zero files touched by both `dev` and `main`.
- No `firestore.rules` / `firebase.json` / config changes; the `devicePrefs` write path is already permitted on main. No migration.
- Full local e2e green; the triggering dev CI run (`e2e.yml`) passed on this SHA.

## Follow-up (post-merge)
`dev` is behind `main` on CI-only commits (#57 workflow hardening, #59 CLI docs test, #35 dependabot/zizmor). This merge does **not** revert them. A `main → dev` back-merge will run after this lands to resync the branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)