### PR TITLE
fix(web): downsample metrics charts uniformly over time, not array index

### DIFF
--- a/web/__tests__/lib/metricsDownsample.test.ts
+++ b/web/__tests__/lib/metricsDownsample.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for lib/metricsDownsample.ts — time-uniform chart downsampling.
+ *
+ * The regression suite at the bottom replays the useHistoricalMetrics
+ * streaming pipeline (oldest-first buckets, in-loop trim, final display
+ * reduction, gap markers) that used to render month/year charts with only
+ * their most recent half visible.
+ */
+
+import { downsampleTimeUniform, insertGapMarkers } from '@/lib/metricsDownsample';
+
+interface Point {
+  time: number;
+  cpu: number | null;
+}
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/** `count` samples starting at `start`, one every `intervalMs`. */
+function makeSeries(start: number, count: number, intervalMs: number): Point[] {
+  return Array.from({ length: count }, (_, i) => ({
+    time: start + i * intervalMs,
+    cpu: 10,
+  }));
+}
+
+const makeGap = (time: number): Point => ({ time, cpu: null });
+
+describe('downsampleTimeUniform', () => {
+  const start = Date.UTC(2026, 5, 28);
+
+  it('returns input unchanged when at or under the target count', () => {
+    const samples = makeSeries(start, 100, MINUTE);
+    expect(downsampleTimeUniform(samples, 100, start, start + HOUR)).toBe(samples);
+    expect(downsampleTimeUniform(samples, 200, start, start + HOUR)).toBe(samples);
+  });
+
+  it('reduces uniform data to roughly the target count', () => {
+    const samples = makeSeries(start, 10_000, MINUTE);
+    const result = downsampleTimeUniform(samples, 400, start, start + 10_000 * MINUTE);
+    expect(result.length).toBeGreaterThanOrEqual(400);
+    expect(result.length).toBeLessThanOrEqual(401);
+  });
+
+  it('always includes the last sample', () => {
+    const samples = makeSeries(start, 5_000, MINUTE);
+    const result = downsampleTimeUniform(samples, 300, start, start + 5_000 * MINUTE);
+    expect(result[result.length - 1]).toBe(samples[samples.length - 1]);
+  });
+
+  it('spreads kept samples uniformly over time, not array index', () => {
+    // Non-uniform density: first half of the window at 1 sample/10min, second
+    // half at 1 sample/min. An index-stepped downsample would keep ~10x more
+    // points in the dense half; a time-uniform one keeps them near-equal per
+    // unit time (the sparse half keeps everything it has).
+    const span = 10 * DAY;
+    const sparse = makeSeries(start, (5 * DAY) / (10 * MINUTE), 10 * MINUTE);
+    const dense = makeSeries(start + 5 * DAY, (5 * DAY) / MINUTE, MINUTE);
+    const result = downsampleTimeUniform([...sparse, ...dense], 400, start, start + span);
+
+    const firstHalf = result.filter((p) => p.time < start + 5 * DAY).length;
+    const secondHalf = result.length - firstHalf;
+    // 400 slots over 10 days = 36min slots. Sparse half: one 10-min sample per
+    // slot -> ~200 kept. Dense half: capped at one per slot -> ~200 kept.
+    expect(firstHalf).toBeGreaterThanOrEqual(190);
+    expect(secondHalf).toBeGreaterThanOrEqual(190);
+    expect(Math.abs(firstHalf - secondHalf)).toBeLessThanOrEqual(20);
+  });
+
+  it('is idempotent: re-trimming already-trimmed data changes nothing', () => {
+    const samples = makeSeries(start, 21_600, 2 * MINUTE); // 30 days @ 2min
+    const domainEnd = start + 30 * DAY;
+    const once = downsampleTimeUniform(samples, 5_000, start, domainEnd);
+    const twice = downsampleTimeUniform(once, 5_000, start, domainEnd);
+    expect(twice).toEqual(once);
+  });
+
+  it('preserves genuine offline gaps instead of fabricating points', () => {
+    // 2 days of data, then 3 days offline, then 2 days of data.
+    const before = makeSeries(start, (2 * DAY) / MINUTE, MINUTE);
+    const after = makeSeries(start + 5 * DAY, (2 * DAY) / MINUTE, MINUTE);
+    const result = downsampleTimeUniform([...before, ...after], 400, start, start + 7 * DAY);
+    const inGap = result.filter(
+      (p) => p.time > start + 2 * DAY && p.time < start + 5 * DAY
+    );
+    expect(inGap).toHaveLength(0);
+  });
+
+  it('handles degenerate inputs', () => {
+    expect(downsampleTimeUniform([], 100, start, start + HOUR)).toEqual([]);
+    const one = makeSeries(start, 1, MINUTE);
+    expect(downsampleTimeUniform(one, 100, start, start + HOUR)).toBe(one);
+    // Zero-width domain: fall back to the most recent points rather than NaN slots.
+    const samples = makeSeries(start, 500, MINUTE);
+    const collapsed = downsampleTimeUniform(samples, 100, start, start);
+    expect(collapsed.length).toBeLessThanOrEqual(100);
+    expect(collapsed[collapsed.length - 1]).toBe(samples[samples.length - 1]);
+  });
+});
+
+describe('insertGapMarkers', () => {
+  const start = Date.UTC(2026, 6, 1);
+
+  it('inserts no markers into evenly spaced data', () => {
+    const samples = makeSeries(start, 100, MINUTE);
+    expect(insertGapMarkers(samples, makeGap)).toHaveLength(100);
+  });
+
+  it('inserts a null marker inside a gap larger than 3x the median interval', () => {
+    const before = makeSeries(start, 50, MINUTE);
+    const after = makeSeries(start + 50 * MINUTE + 2 * HOUR, 50, MINUTE);
+    const result = insertGapMarkers([...before, ...after], makeGap);
+    expect(result).toHaveLength(101);
+    const marker = result[50];
+    expect(marker.cpu).toBeNull();
+    expect(marker.time).toBe(before[before.length - 1].time + 1);
+  });
+
+  it('never flags gaps under the 5-minute floor', () => {
+    // 10s cadence with one 3-minute gap: 3min > 3x median but < 5min floor.
+    const before = makeSeries(start, 30, 10 * 1000);
+    const after = makeSeries(before[before.length - 1].time + 3 * MINUTE, 30, 10 * 1000);
+    expect(insertGapMarkers([...before, ...after], makeGap)).toHaveLength(60);
+  });
+
+  it('passes through short arrays untouched', () => {
+    expect(insertGapMarkers([], makeGap)).toEqual([]);
+    const one = makeSeries(start, 1, MINUTE);
+    expect(insertGapMarkers(one, makeGap)).toBe(one);
+  });
+});
+
+describe('regression: month-view streaming pipeline keeps the whole range visible', () => {
+  // Mirrors useHistoricalMetrics: samples arrive oldest-first, the buffer is
+  // trimmed to MAX_FETCHED_SAMPLES whenever it exceeds 2x that, then the final
+  // pass reduces to MAX_POINTS and inserts gap markers.
+  const MAX_FETCHED_SAMPLES = 5_000;
+  const MAX_POINTS = 400;
+
+  function runPipeline(all: Point[], domainStart: number, domainEnd: number): Point[] {
+    const buffer: Point[] = [];
+    for (const sample of all) {
+      buffer.push(sample);
+      if (buffer.length > MAX_FETCHED_SAMPLES * 2) {
+        buffer.sort((a, b) => a.time - b.time);
+        buffer.splice(
+          0,
+          buffer.length,
+          ...downsampleTimeUniform(buffer, MAX_FETCHED_SAMPLES, domainStart, domainEnd)
+        );
+      }
+    }
+    buffer.sort((a, b) => a.time - b.time);
+    const downsampled = downsampleTimeUniform(buffer, MAX_POINTS, domainStart, domainEnd);
+    return insertGapMarkers(downsampled, makeGap);
+  }
+
+  it('represents every part of a fully-populated month evenly, with no isolated points', () => {
+    const start = Date.UTC(2026, 5, 28);
+    const span = 30 * DAY;
+    // 30 days at 2-min cadence (~21,600 samples) — the volume that triggered
+    // two in-loop trims and rendered only the back half of the month.
+    const samples = makeSeries(start, span / (2 * MINUTE), 2 * MINUTE);
+    const final = runPipeline(samples, start, start + span);
+
+    const real = final.filter((p) => p.cpu !== null);
+    expect(final.length - real.length).toBe(0); // continuous data -> no gap markers
+
+    // Every decile of the month is represented within ~2x of the mean.
+    const deciles = new Array<number>(10).fill(0);
+    for (const p of real) {
+      deciles[Math.min(9, Math.floor(((p.time - start) / span) * 10))]++;
+    }
+    const mean = real.length / 10;
+    for (const count of deciles) {
+      expect(count).toBeGreaterThan(mean / 2);
+      expect(count).toBeLessThan(mean * 2);
+    }
+
+    // No real point is flanked by nulls/edges on both sides (such points are
+    // invisible with dot={false} — the visual symptom of the original bug).
+    for (let i = 0; i < final.length; i++) {
+      if (final[i].cpu === null) continue;
+      const prevBreak = i === 0 || final[i - 1].cpu === null;
+      const nextBreak = i === final.length - 1 || final[i + 1].cpu === null;
+      expect(prevBreak && nextBreak).toBe(false);
+    }
+  });
+
+  it('survives year-scale volume (~12 trims) without starving old data', () => {
+    const start = Date.UTC(2026, 3, 29);
+    const span = 90 * DAY; // retention-capped "year" view
+    const samples = makeSeries(start, span / (2 * MINUTE), 2 * MINUTE);
+    const final = runPipeline(samples, start, start + span);
+
+    const real = final.filter((p) => p.cpu !== null);
+    const firstQuarter = real.filter((p) => p.time < start + span / 4).length;
+    expect(firstQuarter).toBeGreaterThan(real.length / 8);
+  });
+});

--- a/web/hooks/useHistoricalMetrics.ts
+++ b/web/hooks/useHistoricalMetrics.ts
@@ -22,6 +22,7 @@ import {
   DAY_BUCKET_ID_RE,
   HOUR_BUCKET_ID_RE,
 } from '@/lib/metricsHistoryBuckets';
+import { downsampleTimeUniform, insertGapMarkers } from '@/lib/metricsDownsample';
 import type { TimeRange } from '@/components/charts';
 
 /**
@@ -155,65 +156,20 @@ function getBucketIds(start: Date, end: Date): string[] {
 }
 
 /**
- * Downsample data for performance (max points per range)
+ * All-null point of the chart's shape, used by insertGapMarkers to break the
+ * line across offline periods. Dynamic per-NIC/per-disk keys are simply absent,
+ * which Recharts treats the same as null.
  */
-function downsampleForDisplay(
-  samples: ChartDataPoint[],
-  targetCount: number
-): ChartDataPoint[] {
-  if (samples.length <= targetCount) return samples;
-
-  const step = Math.ceil(samples.length / targetCount);
-  const result: ChartDataPoint[] = [];
-
-  for (let i = 0; i < samples.length; i += step) {
-    result.push(samples[i]);
-  }
-
-  // Always include the last sample
-  if (result[result.length - 1] !== samples[samples.length - 1]) {
-    result.push(samples[samples.length - 1]);
-  }
-
-  return result;
-}
-
-/**
- * Insert null-value gap markers where consecutive samples are too far apart.
- * This causes Recharts to break the line instead of interpolating across offline periods.
- * Gap threshold = 3x the median interval between consecutive points.
- */
-function insertGapMarkers(samples: ChartDataPoint[]): ChartDataPoint[] {
-  if (samples.length < 2) return samples;
-
-  // Calculate all intervals
-  const intervals: number[] = [];
-  for (let i = 1; i < samples.length; i++) {
-    intervals.push(samples[i].time - samples[i - 1].time);
-  }
-
-  // Use median interval to determine gap threshold (robust to outliers)
-  const sorted = [...intervals].sort((a, b) => a - b);
-  const median = sorted[Math.floor(sorted.length / 2)];
-  const gapThreshold = Math.max(median * 3, 5 * 60 * 1000); // At least 5 minutes
-
-  const result: ChartDataPoint[] = [];
-  for (let i = 0; i < samples.length; i++) {
-    if (i > 0 && samples[i].time - samples[i - 1].time > gapThreshold) {
-      // Insert a null marker at the midpoint of the gap
-      result.push({
-        time: samples[i - 1].time + 1,
-        cpu: null,
-        memory: null,
-        disk: null,
-        gpu: null,
-        cpuTemp: null,
-        gpuTemp: null,
-      });
-    }
-    result.push(samples[i]);
-  }
-  return result;
+function makeGapPoint(time: number): ChartDataPoint {
+  return {
+    time,
+    cpu: null,
+    memory: null,
+    disk: null,
+    gpu: null,
+    cpuTemp: null,
+    gpuTemp: null,
+  };
 }
 
 /**
@@ -407,9 +363,24 @@ export function useHistoricalMetrics(
 
             allSamples.push(point);
 
+            // Memory guard for large ranges. MUST be time-uniform over the
+            // full window: buckets stream oldest-first, so an index-stepped
+            // trim here re-thins the oldest data on every pass while new
+            // samples arrive at full density — that recency bias is what made
+            // month/year charts render only their back half. Slot sampling is
+            // idempotent for already-trimmed regions, so old data survives any
+            // number of passes. For 'all', startDate is epoch 0 — anchor the
+            // window at the earliest sample instead (stable across passes
+            // because buckets arrive in chronological order).
             if (allSamples.length > MAX_FETCHED_SAMPLES * 2) {
               allSamples.sort((a, b) => a.time - b.time);
-              allSamples.splice(0, allSamples.length, ...downsampleForDisplay(allSamples, MAX_FETCHED_SAMPLES));
+              const domainStart =
+                timeRange === 'all' ? allSamples[0].time : startDate.getTime();
+              allSamples.splice(
+                0,
+                allSamples.length,
+                ...downsampleTimeUniform(allSamples, MAX_FETCHED_SAMPLES, domainStart, now.getTime())
+              );
             }
           }
         }
@@ -418,10 +389,15 @@ export function useHistoricalMetrics(
       // Sort by timestamp
       allSamples.sort((a, b) => a.time - b.time);
 
-      // Downsample for performance
+      // Downsample for display — time-uniform over the same window the chart's
+      // X-axis renders, so every part of the range is represented equally.
       const maxPoints = MAX_POINTS[timeRange];
-      const downsampled = downsampleForDisplay(allSamples, maxPoints);
-      const finalData = insertGapMarkers(downsampled);
+      const domainStart =
+        timeRange === 'all' && allSamples.length > 0
+          ? allSamples[0].time
+          : startDate.getTime();
+      const downsampled = downsampleTimeUniform(allSamples, maxPoints, domainStart, now.getTime());
+      const finalData = insertGapMarkers(downsampled, makeGapPoint);
 
       setData(finalData);
       lastFetchRef.current = Date.now();

--- a/web/lib/metricsDownsample.ts
+++ b/web/lib/metricsDownsample.ts
@@ -1,0 +1,104 @@
+/**
+ * Time-series downsampling for metrics charts (single source of truth)
+ *
+ * Used by useHistoricalMetrics for both its in-loop memory trim and the final
+ * display reduction. The core invariant: downsampling must be uniform over
+ * TIME, not over array index.
+ *
+ * Why that matters: samples stream in oldest-first, and the in-loop trim used
+ * to re-downsample the accumulated (oldest) data every time the buffer filled,
+ * while newer samples kept arriving at full density. After k trims the oldest
+ * region held ~(1/3)^k of its samples. The final index-stepped downsample then
+ * preserved that recency bias, and the gap-marker pass — whose threshold is the
+ * median interval, dominated by the dense recent half — flanked every sparse
+ * old point with nulls. Recharts draws nothing for an isolated point between
+ * nulls (lines render with dot={false}), so month/year/all charts appeared to
+ * start halfway through the range even though every bucket existed in
+ * Firestore.
+ *
+ * Slot sampling over a fixed [domainStart, domainEnd] has no such bias: each
+ * slot keeps its first sample, so a region's survival doesn't depend on how
+ * many trims it lived through — re-trimming already-trimmed data is a no-op
+ * (at most one sample per slot either way).
+ */
+
+/** Minimal shape both helpers need. ChartDataPoint satisfies this. */
+export interface TimedPoint {
+  time: number; // milliseconds
+}
+
+/**
+ * Reduce `samples` (sorted ascending by time) to at most `targetCount + 1`
+ * points, uniformly over the [domainStart, domainEnd] time window: the window
+ * is divided into `targetCount` equal slots and the first sample in each slot
+ * is kept. The last sample is always included so the line reaches "now".
+ *
+ * Slots where the machine was offline simply keep nothing — genuine gaps
+ * survive for insertGapMarkers to mark.
+ */
+export function downsampleTimeUniform<T extends TimedPoint>(
+  samples: T[],
+  targetCount: number,
+  domainStart: number,
+  domainEnd: number
+): T[] {
+  if (samples.length <= targetCount) return samples;
+
+  const span = domainEnd - domainStart;
+  if (span <= 0 || targetCount <= 0) return samples.slice(-Math.max(1, targetCount));
+
+  const slotWidth = span / targetCount;
+  const result: T[] = [];
+  let lastSlot = -1;
+
+  for (const sample of samples) {
+    const slot = Math.min(
+      targetCount - 1,
+      Math.max(0, Math.floor((sample.time - domainStart) / slotWidth))
+    );
+    if (slot !== lastSlot) {
+      result.push(sample);
+      lastSlot = slot;
+    }
+  }
+
+  const lastSample = samples[samples.length - 1];
+  if (result[result.length - 1] !== lastSample) {
+    result.push(lastSample);
+  }
+
+  return result;
+}
+
+/**
+ * Insert gap markers where consecutive samples are too far apart, so Recharts
+ * breaks the line instead of interpolating across offline periods. The gap
+ * point is produced by `makeGapPoint` (callers supply an all-null point of
+ * their chart's shape). Threshold = 3x the median interval between consecutive
+ * points (robust to outliers), floored at 5 minutes.
+ */
+export function insertGapMarkers<T extends TimedPoint>(
+  samples: T[],
+  makeGapPoint: (time: number) => T
+): T[] {
+  if (samples.length < 2) return samples;
+
+  const intervals: number[] = [];
+  for (let i = 1; i < samples.length; i++) {
+    intervals.push(samples[i].time - samples[i - 1].time);
+  }
+
+  const sorted = [...intervals].sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  const gapThreshold = Math.max(median * 3, 5 * 60 * 1000); // At least 5 minutes
+
+  const result: T[] = [];
+  for (let i = 0; i < samples.length; i++) {
+    if (i > 0 && samples[i].time - samples[i - 1].time > gapThreshold) {
+      // Null marker at the start of the gap breaks the line segment.
+      result.push(makeGapPoint(samples[i - 1].time + 1));
+    }
+    result.push(samples[i]);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Fixes the month/year/all metrics charts rendering only the most recent ~half of the range despite complete data in Firestore (reported on dev.owlette.app month view — line started ~46% through the month).
- Root cause: `useHistoricalMetrics` streamed buckets oldest-first and its in-loop memory trim re-downsampled the accumulated (oldest) samples on every pass while newer samples kept arriving at full density. The final index-stepped downsample preserved that recency bias, and the gap-marker pass (median-interval threshold dominated by the dense recent half) flanked the sparse old points with nulls — invisible with `dot={false}`.
- Fix: extracted downsampling into `web/lib/metricsDownsample.ts` using time-uniform slot sampling over the chart's fixed X-axis window. Slot sampling is idempotent for already-trimmed regions, so old data survives any number of trim passes. Also mildly improves the min/avg/max stat cards, which were recency-biased for the same reason.
- Audited all ranges against real data volumes (~29 samples/hour): hour/day/week never hit the trim threshold and are unchanged; month (~21k samples) and year/all (~63k) were broken and are now uniform.

## Testing
- 13 new unit tests in `__tests__/lib/metricsDownsample.test.ts`, including regression replays of the exact streaming pipeline at month and year volumes (decile-uniformity + no invisible isolated points).
- Full unit suite: 2,738 passed. Local e2e: 296 passed. CI e2e on dev: green (run 30338785368).

🤖 Generated with [Claude Code](https://claude.com/claude-code)