### PR TITLE
feat: denser chart gridlines, self-plotting loader, 400-day retention

### DIFF
--- a/web/app/api/cron/retention/route.ts
+++ b/web/app/api/cron/retention/route.ts
@@ -36,9 +36,24 @@ import { FieldPath, Timestamp } from 'firebase-admin/firestore';
 import { getAdminDb } from '@/lib/firebase-admin';
 import { formatDayBucketId } from '@/lib/metricsHistoryBuckets';
 
-/** Retention windows, in days. Mirrored in the privacy policy (section 6). */
-export const METRICS_RETENTION_DAYS = 90;
-export const LOGS_RETENTION_DAYS = 90;
+/**
+ * Retention windows, in days. Mirrored in the privacy policy (section 6) — these
+ * are a PUBLIC COMMITMENT, so the constant and the policy text move together.
+ *
+ * 400, not 365, and NOT 360. MetricsDetailPanel's "year" range resolves to
+ * exactly `now - 365 days` (useHistoricalMetrics.getStartDate), so anything
+ * below that silently truncates the chart — it renders fine, just with less
+ * history than its own label claims, which is the kind of wrong nobody
+ * notices. 365 exactly would leave the oldest bucket sitting on the deletion
+ * boundary between cron runs; the extra ~5 weeks means the year view is always
+ * fully backed.
+ *
+ * The "all" range is unbounded (`new Date(0)`), so no finite window satisfies
+ * it by definition — it shows whatever is retained, which is the honest
+ * reading of "all".
+ */
+export const METRICS_RETENTION_DAYS = 400;
+export const LOGS_RETENTION_DAYS = 400;
 
 /** Ceiling on documents removed per invocation, across both collections. */
 const MAX_DELETES_PER_RUN = 2_000;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -437,6 +437,22 @@ input[type="week"] {
   animation: display-test-result-flash 1100ms ease-out 1;
 }
 
+/* Chart loading — a miniature line graph that plots itself on a loop
+   (ChartLoadingIndicator). Requires pathLength=100 on the path so the dash
+   math is geometry-independent: draw the line, hold, fade, repeat. The
+   restart is seamless because opacity returns to 1 only once the dash offset
+   is back at 100 (nothing drawn yet). */
+@keyframes chart-plot-draw {
+  0%   { stroke-dashoffset: 100; opacity: 1; }
+  65%  { stroke-dashoffset: 0;   opacity: 1; }
+  82%  { stroke-dashoffset: 0;   opacity: 1; }
+  100% { stroke-dashoffset: 0;   opacity: 0; }
+}
+.animate-chart-plot-draw {
+  stroke-dasharray: 100;
+  animation: chart-plot-draw 2.4s ease-in-out infinite;
+}
+
 /* Cortex markdown styling */
 .cortex-markdown {
   line-height: 1.75;

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -202,8 +202,8 @@ export default function PrivacyPage() {
                 <li><strong>account data:</strong> for as long as your account is active. when an account is deleted we immediately revoke its API keys, transfer any owned sites to a successor, clear its pending machine commands, and mark the account deleted so it can no longer sign in or reach your data. the underlying user record is then retained in a deleted state for audit and security purposes rather than erased outright &mdash; if you want the record itself erased, ask us and we will process it as an erasure request (see section 9).</li>
                 <li><strong>screenshots:</strong> automatically deleted 30 days after capture. the agent additionally keeps only the most recent 20 captures per machine in its history.</li>
                 <li><strong>queued machine commands:</strong> pending commands expire after 1 hour; completed command records are removed after 24 hours.</li>
-                <li><strong>machine metrics:</strong> automatically deleted 90 days after collection.</li>
-                <li><strong>event logs:</strong> automatically deleted 90 days after the logged event.</li>
+                <li><strong>machine metrics:</strong> automatically deleted 400 days after collection.</li>
+                <li><strong>event logs:</strong> automatically deleted 400 days after the logged event.</li>
                 <li><strong>process and configuration data:</strong> until the machine is removed from your account.</li>
                 <li><strong>cortex conversations:</strong> until you delete them. deleting a conversation removes it from every listing and hides it from the interface; the underlying record is retained in a deleted state. ask us if you need it erased.</li>
                 <li><strong>deployment content:</strong> until you delete the associated release or roost.</li>

--- a/web/components/charts/ChartLoadingIndicator.tsx
+++ b/web/components/charts/ChartLoadingIndicator.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { LoadingWord } from '@/components/LoadingWord';
+
+/**
+ * Loading state for the metrics detail chart — a miniature line graph that
+ * plots itself on a loop above the usual loading verb. Pure CSS: the
+ * `chart-plot-draw` keyframes live in globals.css, and pathLength={100}
+ * normalizes the dash math so the path geometry can change without touching
+ * the keyframes. aria-hidden because the parent loading container already
+ * carries role="status" and the label.
+ */
+export function ChartLoadingIndicator() {
+  return (
+    <div className="flex flex-col items-center gap-3 text-muted-foreground">
+      <svg width="96" height="32" viewBox="0 0 96 32" fill="none" aria-hidden="true">
+        <path
+          d="M2 26 L18 14 L34 22 L50 8 L66 18 L82 5 L94 12"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          pathLength={100}
+          className="animate-chart-plot-draw"
+        />
+      </svg>
+      <div className="animate-pulse text-sm"><LoadingWord /></div>
+    </div>
+  );
+}

--- a/web/components/charts/MetricsDetailPanel.tsx
+++ b/web/components/charts/MetricsDetailPanel.tsx
@@ -43,7 +43,7 @@ import { getNicColors, getDiskColors, getGpuColors, formatThroughput } from '@/l
 import { DISK_IO_COLORS, formatDiskIO, isDiskIOKey, parseDiskIOKey, computeNiceByteTicks } from '@/lib/diskIOUtils';
 import { useAuth } from '@/contexts/AuthContext';
 import { cn } from '@/lib/utils';
-import { LoadingWord } from '@/components/LoadingWord';
+import { ChartLoadingIndicator } from './ChartLoadingIndicator';
 
 interface MetricsDetailPanelProps {
   machineId: string;
@@ -633,19 +633,28 @@ export function MetricsDetailPanel({
   const hour12 = (userPreferences.timeFormat || '12h') === '12h';
 
   // Memoized so Recharts' XAxis/Tooltip don't re-mount on every parent render.
+  // Ticks are denser than labels on the 1d/1m ranges (a gridline per hour/day)
+  // — returning '' keeps the gridline but suppresses the label so the axis
+  // doesn't overcrowd. CartesianGrid draws a vertical line at every tick
+  // regardless of label text.
   const formatXAxisTick = useCallback((timestamp: number): string => {
     const date = new Date(timestamp);
     switch (timeRange) {
       case '1h':
         return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12 });
       case '1d':
-        // Show date at midnight, hour otherwise
+        // Gridline every hour; label only even hours (date at midnight).
+        if (date.getHours() % 2 !== 0) return '';
         return date.getHours() === 0
           ? date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
           : date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12 });
       case '1w':
         return `W${getISOWeek(date)} ${date.toLocaleDateString(undefined, { weekday: 'short' })}`;
       case '1m':
+        // Gridline every midnight; label only at month starts.
+        return date.getDate() === 1
+          ? date.toLocaleDateString(undefined, { month: 'short' })
+          : '';
       case '1y':
         return date.toLocaleDateString(undefined, { month: 'short' });
       case 'all':
@@ -760,28 +769,27 @@ export function MetricsDetailPanel({
     return computeNiceByteTicks(max);
   }, [bytesAxisActive, diskIOMode, effectiveDiskIO, networkMode, selectedNics, chartData, timeDomain]);
 
-  // Explicit ticks keep the x-axis clean: one label per natural unit
-  // (date / week-day / month), no repeats, and no auto-generated gaps where
-  // the data is sparse.
+  // Explicit ticks keep the x-axis clean: one gridline per natural unit
+  // (hour / date / month), no repeats, and no auto-generated gaps where the
+  // data is sparse. Ticks can be denser than labels — formatXAxisTick returns
+  // '' for the in-between ones (1d labels every 2h, 1m labels at month starts).
   const xTicks = useMemo((): number[] | undefined => {
     const [start, end] = timeDomain;
     if (timeRange === '1h') return undefined; // let recharts auto-tick
     const ticks: number[] = [];
     if (timeRange === '1d') {
-      // One tick per hour. Step 2h so 24 labels don't overcrowd.
+      // One tick (gridline) per hour on the hour.
       const d = new Date(start);
       d.setMinutes(0, 0, 0);
       if (d.getTime() < start) d.setHours(d.getHours() + 1);
-      // Align to even hours so midnight is always a tick when in range.
-      while (d.getHours() % 2 !== 0) d.setHours(d.getHours() + 1);
       while (d.getTime() <= end) {
         ticks.push(d.getTime());
-        d.setHours(d.getHours() + 2);
+        d.setHours(d.getHours() + 1);
       }
       return ticks;
     }
-    if (timeRange === '1w') {
-      // One tick per midnight within the range.
+    if (timeRange === '1w' || timeRange === '1m') {
+      // One tick (gridline) per midnight within the range.
       const d = new Date(start);
       d.setHours(0, 0, 0, 0);
       if (d.getTime() < start) d.setDate(d.getDate() + 1);
@@ -791,7 +799,7 @@ export function MetricsDetailPanel({
       }
       return ticks;
     }
-    // 1m / 1y / all: one tick per calendar month start.
+    // 1y / all: one tick per calendar month start.
     const d = new Date(start);
     d.setDate(1);
     d.setHours(0, 0, 0, 0);
@@ -1088,7 +1096,7 @@ export function MetricsDetailPanel({
             aria-busy="true"
             aria-label="loading metrics"
           >
-            <div className="text-muted-foreground animate-pulse text-sm"><LoadingWord /></div>
+            <ChartLoadingIndicator />
           </div>
         ) : (
         <div className="animate-in fade-in duration-100">

--- a/web/content/docs/setup/web-deployment.mdx
+++ b/web/content/docs/setup/web-deployment.mdx
@@ -162,7 +162,7 @@ returns 401.
 | `/api/cron/process-alerts` | `*/3 * * * *` | `X-Cron-Secret` | drains `pending_process_alerts` into email |
 | `/api/cron/display-alerts` | `*/3 * * * *` | `X-Cron-Secret` | drains `pending_display_alerts` into email |
 | `/api/cron/status-ping` | every 60s | `X-Cron-Secret` | writes status pings, publishes to Instatus |
-| `/api/cron/retention` | daily | `X-Cron-Secret` | deletes metrics + logs past 90 days |
+| `/api/cron/retention` | daily | `X-Cron-Secret` | deletes metrics + logs past 400 days |
 | `/api/cortex/escalation` | every 5 min | `Authorization: Bearer` | Cortex autonomous-mode backstop poller |
 
 <Callout type="warning" title={"Two failure modes that are silent"}>
@@ -244,7 +244,7 @@ symptom, so verify a run returns 200 after scheduling it.
 
 ### data retention sweep
 
-Deletes machine metrics and event logs older than 90 days. This is what backs the
+Deletes machine metrics and event logs older than 400 days. This is what backs the
 retention commitment in the privacy policy — without it, that statement is not
 true. Schedule daily, in every environment:
 
@@ -257,7 +257,7 @@ Use cron expression `0 4 * * *` (or any quiet hour). A successful run returns:
 
 ```json
 {"ok":true,"deleted":{"metrics":107,"logs":496},
- "retentionDays":{"metrics":90,"logs":90},"truncated":false}
+ "retentionDays":{"metrics":400,"logs":400},"truncated":false}
 ```
 
 `truncated: true` means the run hit its 2000-document ceiling and older data


### PR DESCRIPTION
## Summary
Two commits, both green on dev CI:

**feat(ui): denser chart gridlines + self-plotting loading animation** (8da6495)
- Month view draws a dotted vertical gridline at every midnight (matching the week view's rhythm); day view draws one every hour instead of every two. Ticks are denser than labels — the tick formatter returns `''` for in-between ticks so gridlines densify without crowding the axis text.
- The metrics panel's loading state swaps the bare pulsing verb for a miniature line graph that plots itself on a loop (pure CSS stroke-dashoffset, `pathLength`-normalized, `currentColor` themed).

**feat(web): extend metrics + event-log retention to 400 days** (ac01b94)
- 90 days silently truncated the chart's year view (`now - 365d`). 400 keeps the oldest bucket clear of the deletion boundary between cron runs. Constant, privacy policy (section 6), and deployment docs move together.

## Testing
- Both commits: lint clean, tsc clean, 2,738 unit tests passed (retention tests import the constants, so they track the new window).
- CI e2e green on dev for both pushes (runs 30345592093, 30346503987).
- Chart changes built and verified in an isolated worktree before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)