### PR TITLE
fix(deployments): auto-computed sha256 checksums - unblock dashboard deployments

### DIFF
--- a/web/__tests__/lib/actions/DeploymentTemplate.test.ts
+++ b/web/__tests__/lib/actions/DeploymentTemplate.test.ts
@@ -116,6 +116,30 @@ describe('createDeploymentTemplate', () => {
     ).rejects.toBeInstanceOf(DeploymentTemplateValidationError);
   });
 
+  it('stores a normalized (lowercased) sha256_checksum', async () => {
+    const digest = 'A'.repeat(32) + 'b'.repeat(32);
+    await createDeploymentTemplate(ctx, {
+      name: 'TD',
+      installer_name: 'td.exe',
+      installer_url: 'https://example.com/td.exe',
+      silent_flags: '/S',
+      sha256_checksum: digest,
+    });
+    expect(setCalls[0].payload.sha256_checksum).toBe(digest.toLowerCase());
+  });
+
+  it('rejects malformed sha256_checksum', async () => {
+    await expect(
+      createDeploymentTemplate(ctx, {
+        name: 'x',
+        installer_name: 'x.exe',
+        installer_url: 'https://example.com/x.exe',
+        silent_flags: '/S',
+        sha256_checksum: 'not-a-hash',
+      }),
+    ).rejects.toBeInstanceOf(DeploymentTemplateValidationError);
+  });
+
   it('rejects bad close_processes', async () => {
     await expect(
       createDeploymentTemplate(ctx, {
@@ -144,6 +168,16 @@ describe('updateDeploymentTemplate', () => {
     expect(setCalls[0].merge).toBe(true);
     expect(setCalls[0].payload.name).toBe('new name');
     expect(setCalls[0].payload.updatedAt).toBe('__SERVER_TS__');
+  });
+
+  it('accepts a checksum-only update', async () => {
+    docState.set('sites/site-a/installer_templates/template-1', {
+      exists: true,
+      data: () => ({ name: 'old' }),
+    });
+    const digest = 'c'.repeat(64);
+    await updateDeploymentTemplate(ctx, 'template-1', { sha256_checksum: digest });
+    expect(setCalls[0].payload.sha256_checksum).toBe(digest);
   });
 
   it('throws DeploymentTemplateNotFoundError when missing', async () => {

--- a/web/__tests__/lib/actions/computeInstallerChecksum.test.ts
+++ b/web/__tests__/lib/actions/computeInstallerChecksum.test.ts
@@ -1,0 +1,192 @@
+/** @jest-environment node */
+
+/**
+ * Tests for the checksum-compute action core
+ * (web/lib/actions/computeInstallerChecksum.server.ts).
+ *
+ * URLs use public IP literals (e.g. https://8.8.8.8/...) so the SSRF
+ * validator never hits DNS. `fetch` is stubbed with minimal response
+ * objects exposing only the surface the action consumes.
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  computeInstallerChecksum,
+  InstallerChecksumError,
+  MAX_INSTALLER_BYTES,
+} from '@/lib/actions/computeInstallerChecksum.server';
+
+interface MockResponseSpec {
+  status?: number;
+  headers?: Record<string, string>;
+  chunks?: Uint8Array[];
+  noBody?: boolean;
+}
+
+function mockResponse({ status = 200, headers = {}, chunks = [], noBody = false }: MockResponseSpec) {
+  const headerMap = new Map(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  let index = 0;
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (key: string) => headerMap.get(key.toLowerCase()) ?? null },
+    body: noBody
+      ? null
+      : {
+          getReader: () => ({
+            read: async () =>
+              index < chunks.length
+                ? { done: false as const, value: chunks[index++] }
+                : { done: true as const, value: undefined },
+            cancel: async () => {},
+          }),
+          cancel: async () => {},
+        },
+  };
+}
+
+const fetchMock = jest.fn();
+const realFetch = global.fetch;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = realFetch;
+});
+
+async function expectChecksumError(
+  promise: Promise<unknown>,
+  code: InstallerChecksumError['code'],
+): Promise<void> {
+  const err = await promise.then(
+    () => {
+      throw new Error('expected computeInstallerChecksum to reject');
+    },
+    (e: unknown) => e,
+  );
+  expect(err).toBeInstanceOf(InstallerChecksumError);
+  expect((err as InstallerChecksumError).code).toBe(code);
+}
+
+describe('computeInstallerChecksum', () => {
+  it('streams the body and returns its sha256 + size', async () => {
+    const chunkA = new Uint8Array([1, 2, 3, 4]);
+    const chunkB = new Uint8Array([5, 6, 7]);
+    fetchMock.mockResolvedValueOnce(mockResponse({ chunks: [chunkA, chunkB] }));
+
+    const result = await computeInstallerChecksum('https://8.8.8.8/installer.exe');
+
+    const expected = createHash('sha256').update(chunkA).update(chunkB).digest('hex');
+    expect(result.sha256_checksum).toBe(expected);
+    expect(result.size_bytes).toBe(7);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://8.8.8.8/installer.exe',
+      expect.objectContaining({ redirect: 'manual' }),
+    );
+  });
+
+  it('rejects non-https and private-ip urls without fetching', async () => {
+    await expectChecksumError(
+      computeInstallerChecksum('http://8.8.8.8/x.exe'),
+      'invalid_url',
+    );
+    await expectChecksumError(
+      computeInstallerChecksum('https://192.168.1.10/x.exe'),
+      'invalid_url',
+    );
+    await expectChecksumError(computeInstallerChecksum(undefined), 'invalid_url');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('follows redirects, resolving relative locations against the current url', async () => {
+    const chunk = new Uint8Array([9, 9]);
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({ status: 302, headers: { location: '/moved/installer.exe' } }),
+      )
+      .mockResolvedValueOnce(mockResponse({ chunks: [chunk] }));
+
+    const result = await computeInstallerChecksum('https://8.8.8.8/installer.exe');
+
+    expect(result.size_bytes).toBe(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://8.8.8.8/moved/installer.exe',
+      expect.objectContaining({ redirect: 'manual' }),
+    );
+  });
+
+  it('re-validates every redirect hop — a bounce to a private ip is rejected', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ status: 302, headers: { location: 'https://10.0.0.5/evil.exe' } }),
+    );
+
+    await expectChecksumError(
+      computeInstallerChecksum('https://8.8.8.8/installer.exe'),
+      'invalid_url',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after too many redirects', async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ status: 302, headers: { location: 'https://8.8.8.8/loop.exe' } }),
+    );
+
+    await expectChecksumError(
+      computeInstallerChecksum('https://8.8.8.8/installer.exe'),
+      'too_many_redirects',
+    );
+  });
+
+  it('refuses a declared content-length over the cap without reading the body', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        headers: { 'content-length': String(MAX_INSTALLER_BYTES + 1) },
+        chunks: [new Uint8Array([1])],
+      }),
+    );
+
+    await expectChecksumError(
+      computeInstallerChecksum('https://8.8.8.8/huge.exe'),
+      'too_large',
+    );
+  });
+
+  it('surfaces http error statuses as fetch_failed', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ status: 404 }));
+    await expectChecksumError(
+      computeInstallerChecksum('https://8.8.8.8/missing.exe'),
+      'fetch_failed',
+    );
+  });
+
+  it('rejects an empty download', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ chunks: [] }));
+    await expectChecksumError(
+      computeInstallerChecksum('https://8.8.8.8/empty.exe'),
+      'fetch_failed',
+    );
+  });
+
+  it('maps a caller abort to cancelled', async () => {
+    const controller = new AbortController();
+    fetchMock.mockImplementationOnce(async (_url, init: RequestInit) => {
+      controller.abort();
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      if (init.signal?.aborted) throw err;
+      throw err;
+    });
+
+    await expectChecksumError(
+      computeInstallerChecksum('https://8.8.8.8/installer.exe', { signal: controller.signal }),
+      'cancelled',
+    );
+  });
+});

--- a/web/__tests__/lib/actions/createSystemPreset.test.ts
+++ b/web/__tests__/lib/actions/createSystemPreset.test.ts
@@ -87,6 +87,11 @@ describe('createSystemPreset — validation', () => {
       { ...validInput, timeout_seconds: Infinity },
       'timeout_seconds',
     ],
+    [
+      'sha256_checksum malformed',
+      { ...validInput, sha256_checksum: 'not-a-hash' },
+      'sha256_checksum',
+    ],
   ])('throws on %s', async (_label, input, field) => {
     await expect(createSystemPreset({ actor }, input)).rejects.toMatchObject({
       name: 'SystemPresetValidationError',
@@ -171,6 +176,13 @@ describe('createSystemPreset — firestore write', () => {
       parallel_install: true,
       timeout_seconds: 900,
     });
+  });
+
+  it('stores a normalized (lowercased) sha256_checksum', async () => {
+    const digest = 'A'.repeat(32) + 'b'.repeat(32);
+    await createSystemPreset({ actor }, { ...validInput, sha256_checksum: digest });
+    const written = mockSet.mock.calls[0][0];
+    expect(written.sha256_checksum).toBe(digest.toLowerCase());
   });
 
   it('trims whitespace from required string fields', async () => {

--- a/web/__tests__/lib/actions/updateSystemPreset.test.ts
+++ b/web/__tests__/lib/actions/updateSystemPreset.test.ts
@@ -58,6 +58,7 @@ describe('updateSystemPreset — validation', () => {
       { parallel_install: 1 as unknown as boolean },
     ],
     ['timeout_seconds non-finite', { timeout_seconds: Infinity }],
+    ['sha256_checksum malformed', { sha256_checksum: 'zz'.repeat(32) }],
   ])('rejects when %s', async (_label, partial) => {
     await expect(
       updateSystemPreset({ actor, presetId: 'preset-x' }, partial),
@@ -79,6 +80,16 @@ describe('updateSystemPreset — firestore write', () => {
       order: 3,
       updatedAt: '__server_timestamp__',
     });
+  });
+
+  it('stores a normalized (lowercased) sha256_checksum', async () => {
+    const digest = 'A'.repeat(32) + 'b'.repeat(32);
+    await updateSystemPreset(
+      { actor, presetId: 'preset-td' },
+      { sha256_checksum: digest },
+    );
+    const written = mockUpdate.mock.calls[0][0];
+    expect(written.sha256_checksum).toBe(digest.toLowerCase());
   });
 
   it('translates firebase NOT_FOUND into SystemPresetNotFoundError', async () => {

--- a/web/app/api/platform/installer-checksum/route.ts
+++ b/web/app/api/platform/installer-checksum/route.ts
@@ -1,0 +1,52 @@
+/**
+ * POST /api/platform/installer-checksum
+ *   body:   { installer_url: string }
+ *   output: { sha256_checksum: string, size_bytes: number }
+ *
+ * Platform-level twin of POST /api/sites/{siteId}/deployments/checksum, used
+ * by the admin system-preset dialog (which has no site context). Same SSRF
+ * guard and streaming hash; gated on SYSTEM_PRESET_MANAGE.
+ *
+ * Internal dashboard utility — not part of the public API surface.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { problemFromError } from '@/lib/apiErrors';
+import { authorizedPlatformHandler } from '@/lib/authorizedHandler.server';
+import { installerChecksumErrorToResponse } from '@/lib/installerChecksumResponse.server';
+import { parseJsonBody } from '@/app/api/_shared';
+import {
+  computeInstallerChecksum,
+  InstallerChecksumError,
+} from '@/lib/actions/computeInstallerChecksum.server';
+
+export const runtime = 'nodejs';
+// Large installers (TouchDesigner ~1 GB) take a while to stream on the
+// Vercel failover origin; Railway (primary) has no function deadline.
+export const maxDuration = 300;
+
+export const POST = authorizedPlatformHandler({
+  capability: 'SYSTEM_PRESET_MANAGE',
+  targetKind: 'preset',
+})(async (request: NextRequest) => {
+  try {
+    const parsed = await parseJsonBody(request);
+    if (!parsed.ok) return parsed.response;
+    const body = (parsed.body ?? {}) as { installer_url?: unknown };
+
+    try {
+      const result = await computeInstallerChecksum(body.installer_url, {
+        signal: request.signal,
+      });
+      return NextResponse.json(result);
+    } catch (err) {
+      if (err instanceof InstallerChecksumError) {
+        return installerChecksumErrorToResponse(err);
+      }
+      throw err;
+    }
+  } catch (err) {
+    return problemFromError(err, 'platform/installer-checksum:POST');
+  }
+});

--- a/web/app/api/platform/system-presets/[presetId]/route.ts
+++ b/web/app/api/platform/system-presets/[presetId]/route.ts
@@ -68,6 +68,7 @@ interface PatchBody {
   verify_path?: unknown;
   close_processes?: unknown;
   parallel_install?: unknown;
+  sha256_checksum?: unknown;
   is_owlette_agent?: unknown;
   timeout_seconds?: unknown;
   order?: unknown;
@@ -109,6 +110,8 @@ export const PATCH = authorizedPlatformHandler<RouteParams>({
             : undefined,
           parallel_install:
             typeof body.parallel_install === 'boolean' ? body.parallel_install : undefined,
+          sha256_checksum:
+            typeof body.sha256_checksum === 'string' ? body.sha256_checksum : undefined,
           is_owlette_agent:
             typeof body.is_owlette_agent === 'boolean' ? body.is_owlette_agent : undefined,
           timeout_seconds:
@@ -168,6 +171,7 @@ interface SerializedPreset {
   verify_path: string | null;
   close_processes: string[];
   parallel_install: boolean;
+  sha256_checksum: string | null;
   is_owlette_agent: boolean;
   timeout_seconds: number | null;
   order: number;
@@ -192,6 +196,7 @@ function serializePreset(id: string, data: Record<string, unknown>): SerializedP
       ? (data.close_processes as unknown[]).filter((p): p is string => typeof p === 'string')
       : [],
     parallel_install: data.parallel_install === true,
+    sha256_checksum: typeof data.sha256_checksum === 'string' ? data.sha256_checksum : null,
     is_owlette_agent: data.is_owlette_agent === true,
     timeout_seconds: typeof data.timeout_seconds === 'number' ? data.timeout_seconds : null,
     order: typeof data.order === 'number' ? data.order : 0,

--- a/web/app/api/platform/system-presets/route.ts
+++ b/web/app/api/platform/system-presets/route.ts
@@ -52,6 +52,7 @@ interface CreateBody {
   verify_path?: unknown;
   close_processes?: unknown;
   parallel_install?: unknown;
+  sha256_checksum?: unknown;
   is_owlette_agent?: unknown;
   timeout_seconds?: unknown;
   order?: unknown;
@@ -95,6 +96,8 @@ export const POST = authorizedPlatformHandler({
             : undefined,
           parallel_install:
             typeof body.parallel_install === 'boolean' ? body.parallel_install : undefined,
+          sha256_checksum:
+            typeof body.sha256_checksum === 'string' ? body.sha256_checksum : undefined,
           is_owlette_agent: body.is_owlette_agent === true,
           timeout_seconds:
             typeof body.timeout_seconds === 'number' ? body.timeout_seconds : undefined,
@@ -126,6 +129,7 @@ interface SerializedPreset {
   verify_path: string | null;
   close_processes: string[];
   parallel_install: boolean;
+  sha256_checksum: string | null;
   is_owlette_agent: boolean;
   timeout_seconds: number | null;
   order: number;
@@ -150,6 +154,7 @@ function serializePreset(id: string, data: Record<string, unknown>): SerializedP
       ? (data.close_processes as unknown[]).filter((p): p is string => typeof p === 'string')
       : [],
     parallel_install: data.parallel_install === true,
+    sha256_checksum: typeof data.sha256_checksum === 'string' ? data.sha256_checksum : null,
     is_owlette_agent: data.is_owlette_agent === true,
     timeout_seconds: typeof data.timeout_seconds === 'number' ? data.timeout_seconds : null,
     order: typeof data.order === 'number' ? data.order : 0,

--- a/web/app/api/sites/[siteId]/deployments/checksum/route.ts
+++ b/web/app/api/sites/[siteId]/deployments/checksum/route.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /api/sites/{siteId}/deployments/checksum
+ *   body:   { installer_url: string }
+ *   output: { sha256_checksum: string, size_bytes: number }
+ *
+ * Streams the installer from `installer_url` server-side and returns its
+ * SHA-256, so the deploy dialog can pin a checksum without the user hashing
+ * files by hand. Agents refuse `install_software` commands without
+ * `sha256_checksum`, so this runs before every dashboard deployment.
+ *
+ * Internal dashboard utility — not part of the public API surface. The URL
+ * goes through the full SSRF guard with per-redirect-hop re-validation (see
+ * `computeInstallerChecksum.server.ts`). The outbound fetch is tied to the
+ * request signal, so closing the dialog cancels the server-side download.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { problemFromError } from '@/lib/apiErrors';
+import { authorizedSiteHandler } from '@/lib/authorizedHandler.server';
+import { installerChecksumErrorToResponse } from '@/lib/installerChecksumResponse.server';
+import {
+  applyAuthDeprecations,
+  readAndParseJsonBody,
+  requireSiteAuthAndScope,
+} from '../../../../_shared';
+import {
+  computeInstallerChecksum,
+  InstallerChecksumError,
+} from '@/lib/actions/computeInstallerChecksum.server';
+
+type RouteParams = { siteId: string };
+
+export const runtime = 'nodejs';
+// Large installers (TouchDesigner ~1 GB) take a while to stream on the
+// Vercel failover origin; Railway (primary) has no function deadline.
+export const maxDuration = 300;
+
+export const POST = authorizedSiteHandler<RouteParams>({
+  capability: 'DEPLOYMENT_MANAGE',
+  siteIdParam: 'path',
+  targetKind: 'deployment',
+})(async (request: NextRequest, _ctx, routeContext) => {
+  try {
+    const { siteId } = await routeContext.params;
+
+    const auth = await requireSiteAuthAndScope(request, siteId, 'write');
+    if (!auth.ok) return auth.response;
+
+    const parsed = await readAndParseJsonBody(request);
+    if (!parsed.ok) return parsed.response;
+    const body = (parsed.body ?? {}) as { installer_url?: unknown };
+
+    try {
+      const result = await computeInstallerChecksum(body.installer_url, {
+        signal: request.signal,
+      });
+      return applyAuthDeprecations(NextResponse.json(result), auth.scopeCheck);
+    } catch (err) {
+      if (err instanceof InstallerChecksumError) {
+        return installerChecksumErrorToResponse(err);
+      }
+      throw err;
+    }
+  } catch (err) {
+    return problemFromError(err, 'sites/[siteId]/deployments/checksum:POST');
+  }
+});

--- a/web/app/api/sites/[siteId]/presets/deployment-template/[templateId]/route.ts
+++ b/web/app/api/sites/[siteId]/presets/deployment-template/[templateId]/route.ts
@@ -65,6 +65,7 @@ export const GET = authorizedSiteHandler<{ siteId: string; templateId: string }>
       verify_path: typeof data.verify_path === 'string' ? data.verify_path : null,
       close_processes: Array.isArray(data.close_processes) ? data.close_processes : null,
       parallel_install: data.parallel_install === true,
+      sha256_checksum: typeof data.sha256_checksum === 'string' ? data.sha256_checksum : null,
       createdAt: timestampToIso(data.createdAt),
       updatedAt: timestampToIso(data.updatedAt),
     });

--- a/web/app/api/sites/[siteId]/presets/deployment-template/route.ts
+++ b/web/app/api/sites/[siteId]/presets/deployment-template/route.ts
@@ -67,6 +67,7 @@ export const POST = authorizedSiteHandler({
       verify_path: body.verify_path,
       close_processes: body.close_processes,
       parallel_install: body.parallel_install,
+      sha256_checksum: body.sha256_checksum,
     };
 
     const result = await createDeploymentTemplate(ctx, input);
@@ -92,6 +93,7 @@ function serializeTemplate(id: string, data: Record<string, unknown>) {
     verify_path: typeof data.verify_path === 'string' ? data.verify_path : null,
     close_processes: Array.isArray(data.close_processes) ? data.close_processes : null,
     parallel_install: data.parallel_install === true,
+    sha256_checksum: typeof data.sha256_checksum === 'string' ? data.sha256_checksum : null,
     createdAt: timestampToIso(data.createdAt),
     updatedAt: timestampToIso(data.updatedAt),
   };

--- a/web/components/DeploymentDialog.tsx
+++ b/web/components/DeploymentDialog.tsx
@@ -7,12 +7,14 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
-import { AlertTriangle, ChevronDown, ChevronRight, Download, Loader2, Pencil, Save, Trash2 } from 'lucide-react';
+import { AlertTriangle, ChevronDown, ChevronRight, Download, Loader2, Pencil, Plus, Save, Trash2 } from 'lucide-react';
 import { toast } from '@/lib/toast';
 import { useMachines, Process } from '@/hooks/useFirestore';
 import { DeploymentTemplate, Deployment } from '@/hooks/useDeployments';
 import { Badge } from '@/components/ui/badge';
 import { useSystemPresets } from '@/hooks/useSystemPresets';
+import { useInstallerChecksum, SHA256_HEX_RE } from '@/hooks/useInstallerChecksum';
+import InstallerChecksumStatus from '@/components/InstallerChecksumStatus';
 import { SelectGroup, SelectLabel } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
@@ -59,6 +61,16 @@ export default function DeploymentDialog({
   const [parallelInstall, setParallelInstall] = useState(false);
   const [editingName, setEditingName] = useState(false);
 
+  // sha256 checksum — required by agents before they run any installer.
+  // Auto-computed server-side from the installer URL; manual entry covers
+  // URLs the web server cannot reach (e.g. LAN-only hosts).
+  const checksum = useInstallerChecksum({
+    endpoint: `/api/sites/${encodeURIComponent(siteId)}/deployments/checksum`,
+    installerUrl,
+    enabled: open,
+  });
+  const { sha256Checksum, checksumStatus, resetChecksum, adoptChecksum } = checksum;
+
   const allMachinesSelected = selectedMachines.size === machines.length && machines.length > 0;
   const onlineMachines = machines.filter(m => m.online);
 
@@ -101,8 +113,25 @@ export default function DeploymentDialog({
       setSelectedProjectIds(new Set());
       setAdditionalProcesses('');
       setParallelInstall(false);
+      setEditingName(false);
+      resetChecksum();
     }
-  }, [open]);
+  }, [open, resetChecksum]);
+
+  const handleNewTemplate = () => {
+    setSelectedItem('');
+    setDeploymentName('');
+    setInstallerName('');
+    setInstallerUrl('');
+    setSilentFlags('');
+    setVerifyPath('');
+    setParallelInstall(false);
+    setSelectedProjectIds(new Set());
+    setAdditionalProcesses('');
+    setShowCloseProcesses(false);
+    setEditingName(true);
+    resetChecksum();
+  };
 
   const handleItemSelect = (value: string) => {
     if (value === 'none') {
@@ -122,6 +151,7 @@ export default function DeploymentDialog({
         setSilentFlags(preset.silent_flags);
         setVerifyPath(preset.verify_path || '');
         setParallelInstall(preset.parallel_install || false);
+        adoptChecksum(preset.sha256_checksum, preset.installer_url);
         if (preset.close_processes?.length) {
           setAdditionalProcesses(preset.close_processes.join(', '));
           setShowCloseProcesses(true);
@@ -139,6 +169,7 @@ export default function DeploymentDialog({
         setSilentFlags(template.silent_flags);
         setVerifyPath(template.verify_path || '');
         setParallelInstall(template.parallel_install || false);
+        adoptChecksum(template.sha256_checksum, template.installer_url);
         if (template.close_processes?.length) {
           setAdditionalProcesses(template.close_processes.join(', '));
           setShowCloseProcesses(true);
@@ -154,6 +185,17 @@ export default function DeploymentDialog({
       // Switch to edit mode so user can type a name
       setEditingName(true);
       toast.error('Enter a name first');
+      return;
+    }
+
+    if (checksumStatus === 'computing') {
+      toast.error('Still computing checksum — one moment');
+      return;
+    }
+    if (!SHA256_HEX_RE.test(sha256Checksum)) {
+      toast.error('Checksum required', {
+        description: 'agents refuse installs without a sha256 checksum. wait for auto-compute or enter one manually.',
+      });
       return;
     }
 
@@ -180,6 +222,7 @@ export default function DeploymentDialog({
       installer_url: installerUrl,
       silent_flags: silentFlags,
       parallel_install: parallelInstall,
+      sha256_checksum: sha256Checksum,
       ...(verifyPath?.trim() ? { verify_path: verifyPath.trim() } : {}),
       ...(templateCloseProcesses.length > 0 ? { close_processes: templateCloseProcesses } : {}),
     };
@@ -220,6 +263,7 @@ export default function DeploymentDialog({
       setSilentFlags('');
       setVerifyPath('');
       setShowDeleteConfirm(false);
+      resetChecksum();
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       toast.error(message || 'Failed to delete template');
@@ -275,6 +319,17 @@ export default function DeploymentDialog({
       return;
     }
 
+    if (checksumStatus === 'computing') {
+      toast.error('Still computing checksum — one moment');
+      return;
+    }
+    if (!SHA256_HEX_RE.test(sha256Checksum)) {
+      toast.error('Checksum required', {
+        description: 'agents refuse installs without a sha256 checksum. wait for auto-compute or enter one manually.',
+      });
+      return;
+    }
+
     setDeploying(true);
 
     try {
@@ -308,6 +363,7 @@ export default function DeploymentDialog({
         installer_url: installerUrl,
         silent_flags: silentFlags,
         parallel_install: parallelInstall,
+        sha256_checksum: sha256Checksum,
         targets: [],
         ...(verifyPath?.trim() ? { verify_path: verifyPath.trim() } : {}),
         ...(closeProcesses.length > 0 ? { close_processes: closeProcesses } : {}),
@@ -333,6 +389,7 @@ export default function DeploymentDialog({
       setSelectedProjectIds(new Set());
       setAdditionalProcesses('');
       setShowCloseProcesses(false);
+      resetChecksum();
 
       onOpenChange(false);
     } catch (error: unknown) {
@@ -427,6 +484,23 @@ export default function DeploymentDialog({
                   </SelectContent>
                 </Select>
               )}
+              {/* New template: clear form and start fresh — always available */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={handleNewTemplate}
+                    className="border-border bg-background text-white hover:bg-muted hover:text-white cursor-pointer shrink-0"
+                  >
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>new template</p>
+                </TooltipContent>
+              </Tooltip>
               {/* Action buttons — hidden for system presets */}
               {!isPresetSelected && (
                 <>
@@ -500,6 +574,8 @@ export default function DeploymentDialog({
             {installerName && (
               <p className="text-xs text-muted-foreground">filename: {installerName}</p>
             )}
+            {/* sha256 checksum — auto-computed server-side, manual fallback */}
+            <InstallerChecksumStatus checksum={checksum} installerUrl={installerUrl} />
           </div>
 
           {/* Silent Flags */}
@@ -739,7 +815,7 @@ export default function DeploymentDialog({
           <Button
             onClick={handleDeploy}
             className="text-gray-900 cursor-pointer"
-            disabled={deploying}
+            disabled={deploying || checksumStatus === 'computing'}
           >
             {deploying ? (
               <>

--- a/web/components/InstallerChecksumStatus.tsx
+++ b/web/components/InstallerChecksumStatus.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * Checksum status row rendered under an installer-URL input. Shows the
+ * auto-compute spinner / resolved digest / error-with-retry, and the manual
+ * entry fallback for URLs the web server cannot reach. State comes from
+ * `useInstallerChecksum` so DeploymentDialog and SystemPresetDialog behave
+ * identically.
+ */
+
+import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { InstallerChecksumState } from '@/hooks/useInstallerChecksum';
+
+interface InstallerChecksumStatusProps {
+  checksum: InstallerChecksumState;
+  installerUrl: string;
+}
+
+export default function InstallerChecksumStatus({
+  checksum,
+  installerUrl,
+}: InstallerChecksumStatusProps) {
+  const {
+    sha256Checksum,
+    checksumStatus,
+    checksumError,
+    manualChecksum,
+    computeChecksum,
+    enterManualChecksum,
+    exitManualChecksum,
+    setManualChecksumValue,
+  } = checksum;
+
+  if (manualChecksum) {
+    return (
+      <div className="space-y-1">
+        <Label htmlFor="manual-checksum" className="text-xs text-muted-foreground">
+          sha256 checksum
+        </Label>
+        <Input
+          id="manual-checksum"
+          placeholder="64-character hex sha256 of the installer"
+          value={sha256Checksum}
+          onChange={(e) => setManualChecksumValue(e.target.value)}
+          className="border-border bg-background text-white font-mono text-xs"
+        />
+        <button
+          type="button"
+          className="text-xs text-muted-foreground hover:text-white underline cursor-pointer"
+          onClick={exitManualChecksum}
+        >
+          compute automatically instead
+        </button>
+      </div>
+    );
+  }
+
+  if (checksumStatus === 'computing') {
+    return (
+      <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        computing sha256 checksum…
+        <button
+          type="button"
+          className="underline cursor-pointer hover:text-white"
+          onClick={enterManualChecksum}
+        >
+          enter manually
+        </button>
+      </p>
+    );
+  }
+
+  if (checksumStatus === 'ready') {
+    return (
+      <p className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono">
+        <CheckCircle2 className="h-3 w-3 text-green-500 shrink-0" />
+        sha256: {sha256Checksum.slice(0, 12)}…{sha256Checksum.slice(-8)}
+      </p>
+    );
+  }
+
+  if (checksumStatus === 'error') {
+    return (
+      <div className="flex items-start gap-1.5 text-xs text-amber-400">
+        <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        <span>
+          {checksumError || 'failed to compute checksum'}{' — '}
+          <button
+            type="button"
+            className="underline cursor-pointer"
+            onClick={() => {
+              const url = installerUrl.trim();
+              if (url) void computeChecksum(url);
+            }}
+          >
+            retry
+          </button>
+          {' or '}
+          <button
+            type="button"
+            className="underline cursor-pointer"
+            onClick={enterManualChecksum}
+          >
+            enter manually
+          </button>
+        </span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/web/components/SystemPresetDialog.tsx
+++ b/web/components/SystemPresetDialog.tsx
@@ -11,6 +11,8 @@ import { Loader2, Sparkles } from 'lucide-react';
 import { toast } from '@/lib/toast';
 import { useSystemPresets, type SystemPreset } from '@/hooks/useSystemPresets';
 import { useAuth } from '@/contexts/AuthContext';
+import { useInstallerChecksum } from '@/hooks/useInstallerChecksum';
+import InstallerChecksumStatus from '@/components/InstallerChecksumStatus';
 
 /**
  * SystemPresetDialog Component
@@ -55,6 +57,14 @@ export default function SystemPresetDialog({
 
   const isEditMode = preset !== null;
 
+  // sha256 checksum — required by agents before they run any installer.
+  const checksum = useInstallerChecksum({
+    endpoint: '/api/platform/installer-checksum',
+    installerUrl,
+    enabled: open,
+  });
+  const { adoptChecksum, resetChecksum } = checksum;
+
   // Load preset data when editing
   useEffect(() => {
     if (preset) {
@@ -69,6 +79,7 @@ export default function SystemPresetDialog({
       setVerifyPath(preset.verify_path || '');
       setTimeoutSeconds(preset.timeout_seconds || 600);
       setOrder(preset.order);
+      adoptChecksum(preset.sha256_checksum, preset.installer_url);
     } else {
       // Reset form for new preset
       setName('');
@@ -82,8 +93,9 @@ export default function SystemPresetDialog({
       setVerifyPath('');
       setTimeoutSeconds(600);
       setOrder(100);
+      resetChecksum();
     }
-  }, [preset, open]);
+  }, [preset, open, adoptChecksum, resetChecksum]);
 
   const handleAutoFillTd = async () => {
     setFetchingTd(true);
@@ -149,6 +161,16 @@ export default function SystemPresetDialog({
       });
       return;
     }
+    if (checksum.checksumStatus === 'computing') {
+      toast.error('Still computing checksum — one moment');
+      return;
+    }
+    if (!checksum.checksumReady) {
+      toast.error('Checksum required', {
+        description: 'agents refuse installs without a sha256 checksum. wait for auto-compute or enter one manually.',
+      });
+      return;
+    }
 
     setSaving(true);
 
@@ -162,6 +184,7 @@ export default function SystemPresetDialog({
         installer_name: installerName,
         installer_url: installerUrl,
         silent_flags: silentFlags,
+        sha256_checksum: checksum.sha256Checksum,
         is_owlette_agent: false,
         timeout_seconds: timeoutSeconds,
         order,
@@ -359,6 +382,8 @@ export default function SystemPresetDialog({
             <p className="text-xs text-muted-foreground">
               direct download link for the installer
             </p>
+            {/* sha256 checksum — auto-computed server-side, manual fallback */}
+            <InstallerChecksumStatus checksum={checksum} installerUrl={installerUrl} />
           </div>
 
           {/* Silent Flags */}
@@ -441,7 +466,7 @@ export default function SystemPresetDialog({
           </Button>
           <Button
             onClick={handleSave}
-            disabled={saving}
+            disabled={saving || checksum.checksumStatus === 'computing'}
             className="text-gray-900 cursor-pointer"
           >
             {saving ? (

--- a/web/e2e/helpers/coverageSeed.ts
+++ b/web/e2e/helpers/coverageSeed.ts
@@ -266,6 +266,7 @@ export async function seedSystemPreset(
     installer_url: 'https://example.test/e2e-template.exe',
     silent_flags: '/S',
     verify_path: 'C:\\Program Files\\E2E\\template.exe',
+    sha256_checksum: 'ab'.repeat(32),
     timeout_seconds: 600,
     order: 10,
     is_owlette_agent: false,

--- a/web/e2e/specs/admin-presets/presets.spec.ts
+++ b/web/e2e/specs/admin-presets/presets.spec.ts
@@ -33,6 +33,10 @@ test('superadmin can list, filter, create, edit, and delete system presets', asy
   await page.locator('#installerName').fill('e2e-created.exe');
   await page.locator('#installerUrl').fill('https://example.test/e2e-created.exe');
   await page.locator('#silentFlags').fill('/S');
+  // Agents require a sha256 checksum; auto-compute can't reach example.test,
+  // so use the manual-entry fallback (link renders in computing/error states).
+  await page.getByRole('button', { name: /^enter manually$/i }).click();
+  await page.locator('#manual-checksum').fill('ef'.repeat(32));
   await page.getByRole('button', { name: /create template/i }).click();
   await expect(page.getByText('E2E Created Template').first()).toBeVisible();
 

--- a/web/e2e/specs/dispatch/create-deployment.spec.ts
+++ b/web/e2e/specs/dispatch/create-deployment.spec.ts
@@ -68,6 +68,13 @@ test('admin creates a deployment — deployment doc + per-target install command
   const installerUrl = `https://example.com/test-installer-${Date.now()}.exe`;
   await dialog.locator('#installer-url').fill(installerUrl);
 
+  // Agents require a sha256 checksum; the dialog auto-computes one from the
+  // URL (unreachable from the test env), so switch to manual entry. The
+  // "enter manually" link renders in both the computing and error states.
+  const sha256 = 'cd'.repeat(32);
+  await dialog.getByRole('button', { name: /^enter manually$/i }).click();
+  await dialog.locator('#manual-checksum').fill(sha256);
+
   // Check the seeded machine in the target list. Each row is a clickable div
   // with the machineId as its visible text + a checkbox; clicking the row
   // toggles the checkbox via toggleMachine.
@@ -94,6 +101,7 @@ test('admin creates a deployment — deployment doc + per-target install command
   expect(deploymentId).toMatch(/^deploy-\d+$/);
   expect(deployment.installer_url).toBe(installerUrl);
   expect(deployment.installer_name).toMatch(/^test-installer-\d+\.exe$/);
+  expect(deployment.sha256_checksum).toBe(sha256);
   // Status: 'in_progress' once the per-machine commands have all landed.
   expect(['pending', 'in_progress']).toContain(deployment.status);
   expect(Array.isArray(deployment.targets)).toBe(true);
@@ -118,5 +126,6 @@ test('admin creates a deployment — deployment doc + per-target install command
   expect(cmd.type).toBe('install_software');
   expect(cmd.deployment_id).toBe(deploymentId);
   expect(cmd.installer_url).toBe(installerUrl);
+  expect(cmd.sha256_checksum).toBe(sha256);
   expect(cmd.status).toBe('pending');
 });

--- a/web/hooks/useDeployments.ts
+++ b/web/hooks/useDeployments.ts
@@ -14,6 +14,7 @@ export interface DeploymentTemplate {
   verify_path?: string;
   close_processes?: string[];
   parallel_install?: boolean;
+  sha256_checksum?: string;
   createdAt: FirestoreTs;
 }
 
@@ -37,6 +38,7 @@ export interface Deployment {
   close_processes?: string[];
   suppress_projects?: string[];
   parallel_install?: boolean;
+  sha256_checksum?: string;
   targets: DeploymentTarget[];
   createdAt: FirestoreTs;
   completedAt?: FirestoreTs;
@@ -77,6 +79,7 @@ export function useDeploymentTemplates(siteId: string) {
             verify_path: data.verify_path,
             close_processes: data.close_processes,
             parallel_install: data.parallel_install,
+            sha256_checksum: data.sha256_checksum,
             createdAt: data.createdAt || Date.now(),
           });
         });
@@ -171,6 +174,7 @@ export function useDeployments(siteId: string) {
             close_processes: data.close_processes,
             suppress_projects: data.suppress_projects,
             parallel_install: data.parallel_install,
+            sha256_checksum: data.sha256_checksum,
             targets: data.targets || [],
             createdAt: data.createdAt || Date.now(),
             completedAt: data.completedAt,
@@ -214,6 +218,7 @@ export function useDeployments(siteId: string) {
       ...(deployment.close_processes?.length ? { close_processes: deployment.close_processes } : {}),
       ...(deployment.suppress_projects?.length ? { suppress_projects: deployment.suppress_projects } : {}),
       ...(deployment.parallel_install ? { parallel_install: true } : {}),
+      ...(deployment.sha256_checksum ? { sha256_checksum: deployment.sha256_checksum } : {}),
     };
 
     const response = await fetch(deploymentsUrl(siteId), {

--- a/web/hooks/useInstallerChecksum.ts
+++ b/web/hooks/useInstallerChecksum.ts
@@ -1,0 +1,175 @@
+'use client';
+
+/**
+ * useInstallerChecksum — shared checksum state for installer-authoring dialogs
+ * (DeploymentDialog + SystemPresetDialog).
+ *
+ * Agents refuse `install_software` commands without `sha256_checksum`, so the
+ * dashboard pins one at authoring time: whenever the installer URL settles on
+ * a new valid https URL, the hook (debounced) POSTs it to `endpoint`, which
+ * streams the binary server-side and returns its SHA-256. Manual entry covers
+ * URLs the web server cannot reach (e.g. LAN-only hosts).
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export const SHA256_HEX_RE = /^[a-f0-9]{64}$/;
+
+const AUTO_COMPUTE_DEBOUNCE_MS = 800;
+
+export type ChecksumStatus = 'idle' | 'computing' | 'ready' | 'error';
+
+export interface InstallerChecksumState {
+  sha256Checksum: string;
+  checksumStatus: ChecksumStatus;
+  checksumError: string;
+  manualChecksum: boolean;
+  /** true when `sha256Checksum` is a well-formed 64-char hex digest. */
+  checksumReady: boolean;
+  computeChecksum: (url: string) => Promise<void>;
+  resetChecksum: () => void;
+  adoptChecksum: (checksum: string | undefined, installerUrl: string) => void;
+  enterManualChecksum: () => void;
+  exitManualChecksum: () => void;
+  setManualChecksumValue: (value: string) => void;
+}
+
+interface UseInstallerChecksumArgs {
+  /** POST endpoint returning `{ sha256_checksum }` for `{ installer_url }`. */
+  endpoint: string;
+  /** current installer URL — watched by the debounced auto-compute effect. */
+  installerUrl: string;
+  /** gate for auto-compute (typically: dialog is open). */
+  enabled: boolean;
+}
+
+export function useInstallerChecksum({
+  endpoint,
+  installerUrl,
+  enabled,
+}: UseInstallerChecksumArgs): InstallerChecksumState {
+  const [sha256Checksum, setSha256Checksum] = useState('');
+  const [checksumStatus, setChecksumStatus] = useState<ChecksumStatus>('idle');
+  const [checksumError, setChecksumError] = useState('');
+  const [manualChecksum, setManualChecksum] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const lastComputedUrlRef = useRef('');
+
+  const resetChecksum = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    lastComputedUrlRef.current = '';
+    setSha256Checksum('');
+    setChecksumStatus('idle');
+    setChecksumError('');
+    setManualChecksum(false);
+  }, []);
+
+  const computeChecksum = useCallback(async (url: string) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    lastComputedUrlRef.current = url;
+    setChecksumStatus('computing');
+    setChecksumError('');
+    setSha256Checksum('');
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ installer_url: url }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        let detail = `failed to compute checksum (${response.status})`;
+        try {
+          const body = await response.json();
+          detail = body.detail ?? body.title ?? detail;
+        } catch { /* non-JSON error body */ }
+        throw new Error(detail);
+      }
+      const result = await response.json();
+      setSha256Checksum(result.sha256_checksum);
+      setChecksumStatus('ready');
+    } catch (error: unknown) {
+      if (controller.signal.aborted) return;
+      lastComputedUrlRef.current = '';
+      setChecksumStatus('error');
+      setChecksumError(error instanceof Error ? error.message : String(error));
+    }
+  }, [endpoint]);
+
+  /** Adopt a stored checksum from a template/preset, or clear for recompute. */
+  const adoptChecksum = useCallback((checksum: string | undefined, url: string) => {
+    abortRef.current?.abort();
+    setManualChecksum(false);
+    setChecksumError('');
+    if (checksum && SHA256_HEX_RE.test(checksum.toLowerCase())) {
+      setSha256Checksum(checksum.toLowerCase());
+      setChecksumStatus('ready');
+      lastComputedUrlRef.current = url;
+    } else {
+      // Legacy doc saved before checksums existed — the auto-compute effect
+      // recomputes from its URL and the next save self-heals the doc.
+      setSha256Checksum('');
+      setChecksumStatus('idle');
+      lastComputedUrlRef.current = '';
+    }
+  }, []);
+
+  const enterManualChecksum = useCallback(() => {
+    abortRef.current?.abort();
+    setManualChecksum(true);
+    setSha256Checksum('');
+    setChecksumStatus('idle');
+    setChecksumError('');
+  }, []);
+
+  const exitManualChecksum = useCallback(() => {
+    setManualChecksum(false);
+    lastComputedUrlRef.current = '';
+    setSha256Checksum('');
+    setChecksumStatus('idle');
+  }, []);
+
+  const setManualChecksumValue = useCallback((value: string) => {
+    const normalized = value.trim().toLowerCase();
+    setSha256Checksum(normalized);
+    setChecksumStatus(SHA256_HEX_RE.test(normalized) ? 'ready' : 'idle');
+  }, []);
+
+  // Auto-compute (debounced) whenever the installer URL settles on a new
+  // valid https URL. Skipped in manual mode and when the checksum for this
+  // exact URL is already known (template/preset selection pre-fills it).
+  useEffect(() => {
+    if (!enabled || manualChecksum) return;
+    const url = installerUrl.trim();
+    let validHttps = false;
+    try {
+      validHttps = new URL(url).protocol === 'https:';
+    } catch { /* incomplete URL while typing */ }
+    if (!validHttps) return;
+    if (url === lastComputedUrlRef.current) return;
+
+    const timer = setTimeout(() => { void computeChecksum(url); }, AUTO_COMPUTE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [installerUrl, enabled, manualChecksum, computeChecksum]);
+
+  // Cancel any in-flight compute on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return {
+    sha256Checksum,
+    checksumStatus,
+    checksumError,
+    manualChecksum,
+    checksumReady: SHA256_HEX_RE.test(sha256Checksum),
+    computeChecksum,
+    resetChecksum,
+    adoptChecksum,
+    enterManualChecksum,
+    exitManualChecksum,
+    setManualChecksumValue,
+  };
+}

--- a/web/hooks/useSystemPresets.ts
+++ b/web/hooks/useSystemPresets.ts
@@ -28,6 +28,7 @@ export interface SystemPreset {
   verify_path?: string;            // Optional verification path
   close_processes?: string[];      // Process exe names to close before install
   parallel_install?: boolean;      // Install alongside existing versions (hides registry keys)
+  sha256_checksum?: string;        // 64-char hex SHA-256 of the installer (agents refuse installs without one)
   is_owlette_agent: boolean;       // Special flag: fetches latest from installer_metadata
   timeout_seconds?: number;        // Optional custom timeout (default 600)
   order: number;                   // Display order in UI

--- a/web/lib/actions/computeInstallerChecksum.server.ts
+++ b/web/lib/actions/computeInstallerChecksum.server.ts
@@ -1,0 +1,175 @@
+/**
+ * computeInstallerChecksum action core.
+ *
+ * Streams an installer binary from a user-supplied https URL and returns its
+ * SHA-256 digest, so the dashboard can pin a checksum at authoring time
+ * without the user hashing files by hand. Agents (>= the 9dccd12 hardening)
+ * refuse `install_software` commands without `sha256_checksum`, so every
+ * deployment/template/preset authored in the UI runs through this.
+ *
+ * Security: the URL goes through the same SSRF guard as webhook endpoints
+ * (`validateWebhookUrl` — https-only, private/loopback/metadata IPs rejected,
+ * DNS-resolved addresses re-checked). Redirects are followed manually and
+ * every hop is re-validated, so a public URL cannot bounce the fetch into an
+ * internal address. The body is hashed in-stream — never buffered whole or
+ * written to disk — and capped at `MAX_INSTALLER_BYTES`.
+ *
+ * Pure action — does not touch HTTP. Route shims:
+ *   - POST /api/sites/{siteId}/deployments/checksum  (DEPLOYMENT_MANAGE)
+ *   - POST /api/platform/installer-checksum          (SYSTEM_PRESET_MANAGE)
+ */
+
+import { createHash } from 'node:crypto';
+import { validateWebhookUrl } from '@/lib/webhookUrl';
+
+/** hard cap on the streamed download — largest media-server installers are ~5 GB. */
+export const MAX_INSTALLER_BYTES = 10 * 1024 * 1024 * 1024; // 10 GiB
+
+const MAX_REDIRECTS = 5;
+
+/** overall deadline; kept under the route shims' `maxDuration = 300`. */
+const COMPUTE_DEADLINE_MS = 270_000;
+
+export type InstallerChecksumErrorCode =
+  | 'invalid_url'
+  | 'fetch_failed'
+  | 'too_many_redirects'
+  | 'too_large'
+  | 'timeout'
+  | 'cancelled';
+
+export class InstallerChecksumError extends Error {
+  code: InstallerChecksumErrorCode;
+  constructor(code: InstallerChecksumErrorCode, message: string) {
+    super(message);
+    this.name = 'InstallerChecksumError';
+    this.code = code;
+  }
+}
+
+export interface InstallerChecksumResult {
+  sha256_checksum: string;
+  size_bytes: number;
+}
+
+export async function computeInstallerChecksum(
+  rawUrl: unknown,
+  opts: { signal?: AbortSignal } = {},
+): Promise<InstallerChecksumResult> {
+  const controller = new AbortController();
+  const deadline = setTimeout(() => controller.abort(), COMPUTE_DEADLINE_MS);
+  const onCallerAbort = () => controller.abort();
+  opts.signal?.addEventListener('abort', onCallerAbort, { once: true });
+
+  const abortError = (): InstallerChecksumError =>
+    opts.signal?.aborted
+      ? new InstallerChecksumError('cancelled', 'checksum computation cancelled by client')
+      : new InstallerChecksumError(
+          'timeout',
+          `checksum computation exceeded ${Math.round(COMPUTE_DEADLINE_MS / 1000)}s`,
+        );
+
+  try {
+    // Resolve redirects manually, SSRF-validating every hop.
+    let currentUrl = typeof rawUrl === 'string' ? rawUrl : '';
+    let response: Response | null = null;
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      const validation = await validateWebhookUrl(currentUrl);
+      if (!validation.ok) {
+        throw new InstallerChecksumError(
+          'invalid_url',
+          validation.detail ?? validation.reason,
+        );
+      }
+
+      let resp: Response;
+      try {
+        resp = await fetch(validation.url, {
+          redirect: 'manual',
+          signal: controller.signal,
+        });
+      } catch (err) {
+        if (controller.signal.aborted) throw abortError();
+        const message = err instanceof Error ? err.message : String(err);
+        throw new InstallerChecksumError('fetch_failed', `download failed: ${message}`);
+      }
+
+      if (resp.status >= 300 && resp.status < 400) {
+        const location = resp.headers.get('location');
+        void resp.body?.cancel().catch(() => {});
+        if (!location) {
+          throw new InstallerChecksumError(
+            'fetch_failed',
+            `redirect (http ${resp.status}) without a location header`,
+          );
+        }
+        currentUrl = new URL(location, validation.url).toString();
+        continue;
+      }
+
+      if (!resp.ok) {
+        void resp.body?.cancel().catch(() => {});
+        throw new InstallerChecksumError('fetch_failed', `download failed with http ${resp.status}`);
+      }
+
+      response = resp;
+      break;
+    }
+    if (!response) {
+      throw new InstallerChecksumError(
+        'too_many_redirects',
+        `more than ${MAX_REDIRECTS} redirects`,
+      );
+    }
+
+    // Refuse early when the server already declares an oversized body.
+    const declaredLength = Number(response.headers.get('content-length') ?? '');
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_INSTALLER_BYTES) {
+      void response.body?.cancel().catch(() => {});
+      throw new InstallerChecksumError(
+        'too_large',
+        `installer exceeds the ${MAX_INSTALLER_BYTES} byte limit`,
+      );
+    }
+
+    if (!response.body) {
+      throw new InstallerChecksumError('fetch_failed', 'response has no body');
+    }
+
+    const hash = createHash('sha256');
+    let sizeBytes = 0;
+    const reader = response.body.getReader();
+    try {
+      for (;;) {
+        let result: ReadableStreamReadResult<Uint8Array>;
+        try {
+          result = await reader.read();
+        } catch (err) {
+          if (controller.signal.aborted) throw abortError();
+          const message = err instanceof Error ? err.message : String(err);
+          throw new InstallerChecksumError('fetch_failed', `download interrupted: ${message}`);
+        }
+        if (result.done) break;
+        sizeBytes += result.value.byteLength;
+        if (sizeBytes > MAX_INSTALLER_BYTES) {
+          throw new InstallerChecksumError(
+            'too_large',
+            `installer exceeds the ${MAX_INSTALLER_BYTES} byte limit`,
+          );
+        }
+        hash.update(result.value);
+      }
+    } finally {
+      void reader.cancel().catch(() => {});
+    }
+
+    if (sizeBytes === 0) {
+      throw new InstallerChecksumError('fetch_failed', 'downloaded file is empty');
+    }
+
+    return { sha256_checksum: hash.digest('hex'), size_bytes: sizeBytes };
+  } finally {
+    clearTimeout(deadline);
+    opts.signal?.removeEventListener('abort', onCallerAbort);
+  }
+}

--- a/web/lib/actions/createDeploymentTemplate.server.ts
+++ b/web/lib/actions/createDeploymentTemplate.server.ts
@@ -20,7 +20,10 @@ export interface CreateDeploymentTemplateInput {
   verify_path?: string;
   close_processes?: string[];
   parallel_install?: boolean;
+  sha256_checksum?: string;
 }
+
+const SHA256_HEX_RE = /^[a-f0-9]{64}$/i;
 
 export interface CreateDeploymentTemplateResult {
   templateId: string;
@@ -91,6 +94,14 @@ export function validateDeploymentTemplateInput(
   if (input.parallel_install !== undefined && typeof input.parallel_install !== 'boolean') {
     throw new DeploymentTemplateValidationError('parallel_install', 'parallel_install must be a boolean');
   }
+  if (input.sha256_checksum !== undefined && input.sha256_checksum !== null) {
+    if (typeof input.sha256_checksum !== 'string' || !SHA256_HEX_RE.test(input.sha256_checksum)) {
+      throw new DeploymentTemplateValidationError(
+        'sha256_checksum',
+        'sha256_checksum must be a 64-character hex SHA-256 hash',
+      );
+    }
+  }
 }
 
 /**
@@ -126,6 +137,9 @@ export async function createDeploymentTemplate(
   }
   if (input.close_processes !== undefined) payload.close_processes = input.close_processes;
   if (input.parallel_install !== undefined) payload.parallel_install = input.parallel_install;
+  if (input.sha256_checksum !== undefined && input.sha256_checksum !== null) {
+    payload.sha256_checksum = input.sha256_checksum.toLowerCase();
+  }
 
   await templateRef.set(payload);
 

--- a/web/lib/actions/createSystemPreset.server.ts
+++ b/web/lib/actions/createSystemPreset.server.ts
@@ -30,10 +30,13 @@ export interface CreateSystemPresetInput {
   verify_path?: string;
   close_processes?: string[];
   parallel_install?: boolean;
+  sha256_checksum?: string;
   is_owlette_agent: boolean;
   timeout_seconds?: number;
   order: number;
 }
+
+const SHA256_HEX_RE = /^[a-f0-9]{64}$/i;
 
 export interface CreateSystemPresetContext {
   actor: UserActor;
@@ -149,6 +152,14 @@ export async function createSystemPreset(
       'timeout_seconds must be a finite number',
     );
   }
+  if (input.sha256_checksum !== undefined) {
+    if (typeof input.sha256_checksum !== 'string' || !SHA256_HEX_RE.test(input.sha256_checksum)) {
+      throw new SystemPresetValidationError(
+        'sha256_checksum',
+        'sha256_checksum must be a 64-character hex SHA-256 hash',
+      );
+    }
+  }
 
   const slug = slugify(input.software_name);
   if (!slug) {
@@ -176,6 +187,7 @@ export async function createSystemPreset(
     verify_path: input.verify_path,
     close_processes: input.close_processes,
     parallel_install: input.parallel_install,
+    sha256_checksum: input.sha256_checksum?.toLowerCase(),
     is_owlette_agent: input.is_owlette_agent,
     timeout_seconds: input.timeout_seconds,
     order: input.order,

--- a/web/lib/actions/updateDeploymentTemplate.server.ts
+++ b/web/lib/actions/updateDeploymentTemplate.server.ts
@@ -41,7 +41,8 @@ function hasDeploymentTemplateUpdate(updates: UpdateDeploymentTemplateInput): bo
     updates.silent_flags !== undefined ||
     updates.verify_path !== undefined ||
     updates.close_processes !== undefined ||
-    updates.parallel_install !== undefined
+    updates.parallel_install !== undefined ||
+    updates.sha256_checksum !== undefined
   );
 }
 
@@ -76,6 +77,9 @@ export async function updateDeploymentTemplate(
   if (updates.verify_path !== undefined) payload.verify_path = updates.verify_path;
   if (updates.close_processes !== undefined) payload.close_processes = updates.close_processes;
   if (updates.parallel_install !== undefined) payload.parallel_install = updates.parallel_install;
+  if (typeof updates.sha256_checksum === 'string') {
+    payload.sha256_checksum = updates.sha256_checksum.toLowerCase();
+  }
 
   await templateRef.set(payload, { merge: true });
 

--- a/web/lib/actions/updateSystemPreset.server.ts
+++ b/web/lib/actions/updateSystemPreset.server.ts
@@ -32,10 +32,13 @@ export interface UpdateSystemPresetInput {
   verify_path?: string;
   close_processes?: string[];
   parallel_install?: boolean;
+  sha256_checksum?: string;
   is_owlette_agent?: boolean;
   timeout_seconds?: number;
   order?: number;
 }
+
+const SHA256_HEX_RE = /^[a-f0-9]{64}$/i;
 
 export interface UpdateSystemPresetContext {
   actor: UserActor;
@@ -153,6 +156,14 @@ export async function updateSystemPreset(
       'timeout_seconds must be a finite number',
     );
   }
+  if (input.sha256_checksum !== undefined) {
+    if (typeof input.sha256_checksum !== 'string' || !SHA256_HEX_RE.test(input.sha256_checksum)) {
+      throw new SystemPresetValidationError(
+        'sha256_checksum',
+        'sha256_checksum must be a 64-character hex SHA-256 hash',
+      );
+    }
+  }
 
   const db = getAdminDb();
   const presetRef = db.collection('system_presets').doc(ctx.presetId);
@@ -169,6 +180,7 @@ export async function updateSystemPreset(
     verify_path: input.verify_path,
     close_processes: input.close_processes,
     parallel_install: input.parallel_install,
+    sha256_checksum: input.sha256_checksum?.toLowerCase(),
     is_owlette_agent: input.is_owlette_agent,
     timeout_seconds: input.timeout_seconds,
     order: input.order,

--- a/web/lib/installerChecksumResponse.server.ts
+++ b/web/lib/installerChecksumResponse.server.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared HTTP mapping for `InstallerChecksumError`, used by both checksum
+ * route shims (site-scoped deployments + platform system-presets). Lives
+ * outside the route files because Next.js route modules may only export
+ * HTTP method handlers and route-segment config.
+ */
+
+import { NextResponse } from 'next/server';
+import { problem, problemValidation, ProblemType } from '@/lib/apiErrors';
+import type { InstallerChecksumError } from '@/lib/actions/computeInstallerChecksum.server';
+
+export function installerChecksumErrorToResponse(err: InstallerChecksumError): NextResponse {
+  switch (err.code) {
+    case 'invalid_url':
+      return problemValidation(err.message, { 'body.installer_url': [err.message] });
+    case 'too_large':
+      return problem({
+        type: ProblemType.PayloadTooLarge,
+        title: 'installer too large',
+        status: 413,
+        detail: err.message,
+        code: 'too_large',
+      });
+    default:
+      // fetch_failed / too_many_redirects / timeout / cancelled — the remote
+      // host (or the client hanging up) is the failing party, not this API.
+      return problem({
+        type: ProblemType.ValidationFailed,
+        title: 'checksum computation failed',
+        status: 422,
+        detail: err.message,
+        code: err.code,
+      });
+  }
+}

--- a/web/openapi.yaml
+++ b/web/openapi.yaml
@@ -2950,6 +2950,11 @@ paths:
                   type: string
                   pattern: '^[a-f0-9]{64}$'
                   nullable: true
+                  description: |
+                    SHA-256 hex digest of the installer binary. Strongly
+                    recommended — agents 2.11.1+ refuse `install_software`
+                    commands that omit it, so deployments created without a
+                    checksum will fail on every up-to-date machine.
                 parallel_install: { type: boolean }
                 close_processes:
                   type: array


### PR DESCRIPTION
## What

Dashboard-created deployments have failed on the fleet since the agent 2.11.1 hardening (`9dccd12`) began refusing `install_software` commands without `sha256_checksum` — the UI never collected one. First hit in prod on a TouchDesigner 2025.33070 deployment.

This ships checksum **automation**: the server streams the installer from its URL at authoring time and pins the SHA-256; nobody hashes files by hand. The agent-side gate stays exactly as-is.

- `computeInstallerChecksum` action: streaming hash, 10 GiB cap, SSRF guard with per-redirect-hop re-validation
- Routes: `POST /api/sites/{siteId}/deployments/checksum` (DEPLOYMENT_MANAGE) + `POST /api/platform/installer-checksum` (SYSTEM_PRESET_MANAGE)
- Shared `useInstallerChecksum` hook + status row in DeploymentDialog and SystemPresetDialog: debounced auto-compute, stored-checksum adoption, manual-entry fallback; deploy/save blocked until a checksum exists
- `sha256_checksum` persisted through deployment templates + system presets; legacy docs self-heal on next save
- Also includes the "+ new template" affordance in the deploy dialog (template creation was undiscoverable)
- openapi: documents the agent-side refusal (field stays optional on the public API — no CLI/SDK break)

## Why a hotfix branch

`dev` is 9 commits ahead with the entire unreleased billing sprint. This cherry-picks only `ae7ce6c` (clean apply, no conflicts) so the deployment fix ships without dragging billing to prod.

## Verification

- Local preflight on dev: lint, typecheck, 3602 unit tests, full e2e (296 passed)
- dev CI: openapi drift ✅ CodeQL ✅ no-token-logs ✅ (e2e in progress at PR time)
- Verified working on dev.owlette.app against a real deployment
- The PR e2e run validates this diff against main without billing present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
