### PR TITLE
fix(deployments): working retry (in-place, checksum self-healing) + dialog UX

### DIFF
--- a/web/__tests__/api/sites-deployments.test.ts
+++ b/web/__tests__/api/sites-deployments.test.ts
@@ -71,6 +71,19 @@ jest.mock('@/lib/authorizedHandler.server', () => ({
 
 const mockResolveAuth = jest.fn();
 const mockAssertSite = jest.fn();
+const mockComputeChecksum = jest.fn();
+
+// The retry route self-heals legacy deployments (no stored checksum) by
+// streaming + hashing the installer. Mock the compute core so tests never
+// perform a network fetch; requireActual keeps InstallerChecksumError's
+// class identity for the route's instanceof mapping.
+jest.mock('@/lib/actions/computeInstallerChecksum.server', () => {
+  const actual = jest.requireActual('@/lib/actions/computeInstallerChecksum.server');
+  return {
+    ...actual,
+    computeInstallerChecksum: (...a: unknown[]) => mockComputeChecksum(...a),
+  };
+});
 
 jest.mock('@/lib/apiAuth.server', () => {
   const actual = jest.requireActual('@/lib/apiAuth.server');
@@ -126,6 +139,10 @@ beforeEach(() => {
   mocks.del.mockResolvedValue(undefined);
   mocks.get.mockImplementation(() => Promise.resolve(docSnapshot('any', null)));
   mocks.collectionGet.mockResolvedValue(querySnapshot([]));
+  mockComputeChecksum.mockResolvedValue({
+    sha256_checksum: 'f0'.repeat(32),
+    size_bytes: 1024,
+  });
 });
 
 const validCreateBody = {
@@ -681,6 +698,140 @@ describe('POST /api/sites/{siteId}/deployments/{deploymentId}/retry', () => {
         attributes: expect.objectContaining({ verb: 'retry', retried_count: 2 }),
       }),
     );
+
+    // Doc had no checksum — self-heal computed one, pinned it on the doc,
+    // and stamped it into every re-issued command.
+    expect(mockComputeChecksum).toHaveBeenCalledWith(
+      'https://example.com/vlc.exe',
+      expect.anything(),
+    );
+    expect(updatePayload.sha256_checksum).toBe('f0'.repeat(32));
+    for (const call of mergeCalls) {
+      const cmd = call[0][Object.keys(call[0])[0]];
+      expect(cmd.sha256_checksum).toBe('f0'.repeat(32));
+    }
+  });
+
+  it('skips checksum compute when the deployment already has one', async () => {
+    queueIdempotencyMiss();
+    mocks.get.mockResolvedValueOnce(
+      docSnapshot(DEPLOYMENT, {
+        installer_name: 'vlc.exe',
+        installer_url: 'https://example.com/vlc.exe',
+        silent_flags: '/S',
+        sha256_checksum: 'ab'.repeat(32),
+        targets: [{ machineId: 'm1', status: 'failed' }],
+        status: 'failed',
+      }),
+    );
+    const req = createMockRequest(
+      `http://localhost/api/sites/${SITE}/deployments/${DEPLOYMENT}/retry`,
+      { method: 'POST', headers: idempotencyHeaders('idem-retry-has-sum'), body: {} },
+    );
+    const res = await retryPOST(req, {
+      params: Promise.resolve({ siteId: SITE, deploymentId: DEPLOYMENT }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockComputeChecksum).not.toHaveBeenCalled();
+
+    const mergeCalls = mocks.set.mock.calls.filter(
+      (c: unknown[]) => (c[1] as { merge?: boolean })?.merge === true,
+    );
+    const cmd = mergeCalls[0][0][Object.keys(mergeCalls[0][0])[0]];
+    expect(cmd.sha256_checksum).toBe('ab'.repeat(32));
+    // No re-pin: doc already had the checksum.
+    expect(mocks.update.mock.calls[0][0].sha256_checksum).toBeUndefined();
+  });
+
+  it('retries only the machines in the body filter', async () => {
+    queueIdempotencyMiss();
+    mocks.get.mockResolvedValueOnce(
+      docSnapshot(DEPLOYMENT, {
+        installer_name: 'vlc.exe',
+        installer_url: 'https://example.com/vlc.exe',
+        silent_flags: '/S',
+        sha256_checksum: 'ab'.repeat(32),
+        targets: [
+          { machineId: 'm1', status: 'failed', error: 'a' },
+          { machineId: 'm2', status: 'failed', error: 'b' },
+        ],
+        status: 'failed',
+      }),
+    );
+    const req = createMockRequest(
+      `http://localhost/api/sites/${SITE}/deployments/${DEPLOYMENT}/retry`,
+      {
+        method: 'POST',
+        headers: idempotencyHeaders('idem-retry-filter'),
+        body: { machines: ['m2'] },
+      },
+    );
+    const res = await retryPOST(req, {
+      params: Promise.resolve({ siteId: SITE, deploymentId: DEPLOYMENT }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.retried).toBe(1);
+    expect(body.machine_ids).toEqual(['m2']);
+
+    // Only one command queued; m1 stays failed with its error intact.
+    const mergeCalls = mocks.set.mock.calls.filter(
+      (c: unknown[]) => (c[1] as { merge?: boolean })?.merge === true,
+    );
+    expect(mergeCalls).toHaveLength(1);
+    const updatePayload = mocks.update.mock.calls[0][0];
+    const m1 = updatePayload.targets.find((t: { machineId: string }) => t.machineId === 'm1');
+    expect(m1.status).toBe('failed');
+    expect(m1.error).toBe('a');
+    const m2 = updatePayload.targets.find((t: { machineId: string }) => t.machineId === 'm2');
+    expect(m2.status).toBe('pending');
+  });
+
+  it('400 when machines filter is malformed', async () => {
+    const req = createMockRequest(
+      `http://localhost/api/sites/${SITE}/deployments/${DEPLOYMENT}/retry`,
+      {
+        method: 'POST',
+        headers: idempotencyHeaders('idem-retry-badfilter'),
+        body: { machines: [] },
+      },
+    );
+    const res = await retryPOST(req, {
+      params: Promise.resolve({ siteId: SITE, deploymentId: DEPLOYMENT }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('surfaces a checksum compute failure without queuing commands', async () => {
+    queueIdempotencyMiss();
+    const { InstallerChecksumError } = jest.requireActual(
+      '@/lib/actions/computeInstallerChecksum.server',
+    );
+    mockComputeChecksum.mockRejectedValueOnce(
+      new InstallerChecksumError('fetch_failed', 'download failed with http 404'),
+    );
+    mocks.get.mockResolvedValueOnce(
+      docSnapshot(DEPLOYMENT, {
+        installer_name: 'vlc.exe',
+        installer_url: 'https://example.com/vlc.exe',
+        silent_flags: '/S',
+        targets: [{ machineId: 'm1', status: 'failed' }],
+        status: 'failed',
+      }),
+    );
+    const req = createMockRequest(
+      `http://localhost/api/sites/${SITE}/deployments/${DEPLOYMENT}/retry`,
+      { method: 'POST', headers: idempotencyHeaders('idem-retry-heal-fail'), body: {} },
+    );
+    const res = await retryPOST(req, {
+      params: Promise.resolve({ siteId: SITE, deploymentId: DEPLOYMENT }),
+    });
+    expect(res.status).toBe(422);
+    const mergeCalls = mocks.set.mock.calls.filter(
+      (c: unknown[]) => (c[1] as { merge?: boolean })?.merge === true,
+    );
+    expect(mergeCalls).toHaveLength(0);
+    expect(mocks.update).not.toHaveBeenCalled();
   });
 
   it('404 when deployment not found', async () => {

--- a/web/app/api/sites/[siteId]/deployments/[deploymentId]/retry/route.ts
+++ b/web/app/api/sites/[siteId]/deployments/[deploymentId]/retry/route.ts
@@ -15,7 +15,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { FieldValue, Timestamp } from 'firebase-admin/firestore';
-import { problem, problemFromError, ProblemType } from '@/lib/apiErrors';
+import { problem, problemFromError, problemValidation, ProblemType } from '@/lib/apiErrors';
 import { getAdminDb } from '@/lib/firebase-admin';
 import {
   applyAuthDeprecations,
@@ -25,9 +25,19 @@ import {
 import { withIdempotency } from '@/lib/idempotency';
 import { authorizedSiteHandler } from '@/lib/authorizedHandler.server';
 import { emitMutation } from '@/lib/auditLogClient';
+import { installerChecksumErrorToResponse } from '@/lib/installerChecksumResponse.server';
+import {
+  computeInstallerChecksum,
+  InstallerChecksumError,
+} from '@/lib/actions/computeInstallerChecksum.server';
 import type { DeploymentTarget } from '@/hooks/useDeployments';
 
 type RouteParams = { siteId: string; deploymentId: string };
+
+export const runtime = 'nodejs';
+// Self-healing legacy deployments streams the installer to pin a checksum —
+// large binaries need headroom on the Vercel failover origin.
+export const maxDuration = 300;
 
 export const POST = authorizedSiteHandler<RouteParams>({
   capability: 'DEPLOYMENT_MANAGE',
@@ -39,6 +49,23 @@ export const POST = authorizedSiteHandler<RouteParams>({
 
     const parsed = await readAndParseJsonBody(request);
     if (!parsed.ok) return parsed.response;
+    const body = (parsed.body ?? {}) as { machines?: unknown };
+
+    // Optional machine filter — retry only the listed failed targets
+    // (per-row retry in the dashboard). Omitted → retry every failed target.
+    let machineFilter: Set<string> | null = null;
+    if (body.machines !== undefined) {
+      if (
+        !Array.isArray(body.machines) ||
+        body.machines.length === 0 ||
+        body.machines.some((m) => typeof m !== 'string' || m.length === 0)
+      ) {
+        return problemValidation('machines must be a non-empty string array when provided', {
+          'body.machines': ['must be a non-empty string array when provided'],
+        });
+      }
+      machineFilter = new Set(body.machines as string[]);
+    }
 
     const auth = await requireSiteAuthAndScope(request, siteId, 'write');
     if (!auth.ok) return auth.response;
@@ -73,14 +100,18 @@ export const POST = authorizedSiteHandler<RouteParams>({
         const targets: DeploymentTarget[] = Array.isArray(data.targets)
           ? (data.targets as DeploymentTarget[])
           : [];
-        const failed = targets.filter((t) => t.status === 'failed');
+        const failed = targets.filter(
+          (t) => t.status === 'failed' && (!machineFilter || machineFilter.has(t.machineId)),
+        );
 
         if (failed.length === 0) {
           return problem({
             type: ProblemType.Conflict,
             title: 'no failed targets',
             status: 409,
-            detail: 'no targets in `failed` state to retry',
+            detail: machineFilter
+              ? 'no targets in `failed` state matching the machines filter'
+              : 'no targets in `failed` state to retry',
             instance: `/api/sites/${siteId}/deployments/${deploymentId}/retry`,
             code: 'no_failed_targets',
           });
@@ -89,7 +120,7 @@ export const POST = authorizedSiteHandler<RouteParams>({
         const installerUrl = typeof data.installer_url === 'string' ? data.installer_url : '';
         const installerName = typeof data.installer_name === 'string' ? data.installer_name : '';
         const silentFlags = typeof data.silent_flags === 'string' ? data.silent_flags : '';
-        const sha256 =
+        let sha256 =
           typeof data.sha256_checksum === 'string' ? data.sha256_checksum : undefined;
         const verifyPath =
           typeof data.verify_path === 'string' ? data.verify_path : undefined;
@@ -103,6 +134,27 @@ export const POST = authorizedSiteHandler<RouteParams>({
             detail: 'deployment record is missing installer_url or installer_name; cannot retry',
             instance: `/api/sites/${siteId}/deployments/${deploymentId}/retry`,
           });
+        }
+
+        // Legacy deployments (created before checksum automation) carry no
+        // pinned checksum — agents refuse install_software without one, so a
+        // bare retry would fail on every target. Compute + pin it now from
+        // the installer URL; on failure, surface the error instead of
+        // queuing commands every agent will refuse.
+        let healedChecksum = false;
+        if (!sha256) {
+          try {
+            const computed = await computeInstallerChecksum(installerUrl, {
+              signal: request.signal,
+            });
+            sha256 = computed.sha256_checksum;
+            healedChecksum = true;
+          } catch (err) {
+            if (err instanceof InstallerChecksumError) {
+              return installerChecksumErrorToResponse(err);
+            }
+            throw err;
+          }
         }
 
         const retryEpoch = Date.now();
@@ -150,7 +202,9 @@ export const POST = authorizedSiteHandler<RouteParams>({
         // ad-hoc fields (retriedAt, error) that aren't on the strict
         // `DeploymentTarget` union — Firestore writes don't need it.
         const updatedTargets: Array<Record<string, unknown>> = targets.map((target) => {
-          if (target.status !== 'failed') return target as unknown as Record<string, unknown>;
+          if (target.status !== 'failed' || (machineFilter && !machineFilter.has(target.machineId))) {
+            return target as unknown as Record<string, unknown>;
+          }
           const { error: _droppedError, ...rest } = target;
           void _droppedError;
           return {
@@ -166,6 +220,9 @@ export const POST = authorizedSiteHandler<RouteParams>({
           updatedAt: FieldValue.serverTimestamp(),
           // Clear completedAt — the deployment is back in flight.
           completedAt: FieldValue.delete(),
+          // Persist a freshly-computed checksum so future retries skip the
+          // download and the doc matches what the commands were issued with.
+          ...(healedChecksum && sha256 ? { sha256_checksum: sha256 } : {}),
         });
 
         emitMutation({

--- a/web/app/deployments/page.tsx
+++ b/web/app/deployments/page.tsx
@@ -49,7 +49,7 @@ const statusColors: Record<string, string> = {
   uninstalled: 'bg-purple-600 hover:bg-purple-700',
   failed: 'bg-red-600 hover:bg-red-700',
   cancelled: 'bg-orange-600 hover:bg-orange-700',
-  in_progress: '',
+  in_progress: 'bg-cyan-600 hover:bg-cyan-700',
   partial: 'bg-yellow-600 hover:bg-yellow-700',
   pending: 'bg-muted hover:bg-muted',
   closing_processes: 'bg-amber-600 hover:bg-amber-700',
@@ -85,9 +85,11 @@ const DeploymentRow = React.memo(function DeploymentRow({
   isSelected,
   onToggle,
   onRetry,
+  onRetryTarget,
   onUninstall,
   onDelete,
   onCancel,
+  retrying,
   timeDisplayMode,
   userTz,
   siteTz,
@@ -97,9 +99,12 @@ const DeploymentRow = React.memo(function DeploymentRow({
   isSelected: boolean;
   onToggle: (id: string) => void;
   onRetry: (deployment: Deployment) => void;
+  onRetryTarget: (deployment: Deployment, machineId: string) => void;
   onUninstall: (deployment: Deployment) => void;
   onDelete: (id: string) => void;
   onCancel: (deploymentId: string, machineId: string, installerName: string) => void;
+  /** in-flight retry keys: deployment id (bulk) or `${deploymentId}:${machineId}` (per-row). */
+  retrying: ReadonlySet<string>;
   timeDisplayMode: 'user' | 'machine' | 'site';
   userTz: string | undefined;
   siteTz: string | undefined;
@@ -107,6 +112,7 @@ const DeploymentRow = React.memo(function DeploymentRow({
 }) {
   const failedTargets = deployment.targets.filter((t: DeploymentTarget) => t.status === 'failed' && t.error);
   const errorMessages = failedTargets.map((t: DeploymentTarget) => `${t.machineId}: ${t.error}`).join('\n');
+  const bulkRetrying = retrying.has(deployment.id);
 
   return (
     <Collapsible
@@ -162,13 +168,14 @@ const DeploymentRow = React.memo(function DeploymentRow({
             <DropdownMenuContent align="end" className="border-border bg-secondary">
               {deployment.targets.some((t: DeploymentTarget) => t.status === 'failed') && (
                 <DropdownMenuItem
+                  disabled={bulkRetrying}
                   onClick={(e) => {
                     e.stopPropagation();
                     onRetry(deployment);
                   }}
                   className="text-foreground focus:bg-accent focus:text-foreground cursor-pointer"
                 >
-                  <RefreshCw className="h-4 w-4 mr-2" />
+                  <RefreshCw className={`h-4 w-4 mr-2 ${bulkRetrying ? 'animate-spin' : ''}`} />
                   retry failed
                 </DropdownMenuItem>
               )}
@@ -233,6 +240,28 @@ const DeploymentRow = React.memo(function DeploymentRow({
                         <span className="text-xs text-muted-foreground">{target.progress}%</span>
                       )}
                       {getStatusBadge(target.status, target.error)}
+                      {target.status === 'failed' && (() => {
+                        const rowRetrying = bulkRetrying || retrying.has(`${deployment.id}:${target.machineId}`);
+                        return (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                disabled={rowRetrying}
+                                onClick={() => onRetryTarget(deployment, target.machineId)}
+                                aria-label={`retry deployment to ${target.machineId}`}
+                                className="h-7 px-2 text-muted-foreground hover:text-foreground hover:bg-muted cursor-pointer"
+                              >
+                                <RefreshCw className={`h-4 w-4 ${rowRetrying ? 'animate-spin' : ''}`} />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>retry this machine</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        );
+                      })()}
                       {(target.status === 'pending' || target.status === 'closing_processes' || target.status === 'downloading' || target.status === 'installing') && (
                         <Button
                           size="sm"
@@ -284,6 +313,7 @@ export default function DeploymentsPage() {
     createTemplate,
     updateTemplate,
     deleteTemplate,
+    retryDeployment,
     cancelDeployment,
     deleteDeployment,
   } = useDeploymentManager(currentSiteId);
@@ -319,36 +349,47 @@ export default function DeploymentsPage() {
   // directly in useCallback deps recreates handlers on every render and
   // defeats React.memo on DeploymentRow. Keep a latest-ref and depend on
   // nothing, so the handlers keep stable identity for the whole list.
-  const createDeploymentRef = useRef(createDeployment);
-  createDeploymentRef.current = createDeployment;
+  const retryDeploymentRef = useRef(retryDeployment);
+  retryDeploymentRef.current = retryDeployment;
 
-  const handleRetryDeployment = useCallback(async (deployment: Deployment) => {
+  // In-flight retry keys: deployment id (bulk) or `${deploymentId}:${machineId}`
+  // (per-row). Drives disabled state + spinner on retry controls — the retry
+  // endpoint may stream + hash the installer to self-heal a legacy
+  // deployment's missing checksum, which takes a while for large binaries.
+  const [retrying, setRetrying] = useState<ReadonlySet<string>>(new Set());
+
+  const runRetry = useCallback(async (deployment: Deployment, machineIds?: string[]) => {
+    const key = machineIds?.length === 1
+      ? `${deployment.id}:${machineIds[0]}`
+      : deployment.id;
+    setRetrying((prev) => new Set(prev).add(key));
     try {
-      const failedTargets = deployment.targets.filter((t: DeploymentTarget) => t.status === 'failed');
-
-      if (failedTargets.length === 0) {
-        toast.error('no failed targets to retry');
-        return;
-      }
-
-      const machineIds = failedTargets.map((t: DeploymentTarget) => t.machineId);
-
-      await createDeploymentRef.current({
-        name: `${deployment.name} (Retry)`,
-        installer_name: deployment.installer_name,
-        installer_url: deployment.installer_url,
-        silent_flags: deployment.silent_flags,
-        verify_path: deployment.verify_path,
-        targets: [],
-      }, machineIds);
-
-      toast.success(`retrying deployment for ${failedTargets.length} failed machine(s)`);
+      const retried = await retryDeploymentRef.current(deployment.id, machineIds);
+      toast.success(`retrying deployment for ${retried} machine(s)`);
     } catch (error: unknown) {
       console.error('Failed to retry deployment:', error);
       const message = error instanceof Error ? error.message : String(error);
       toast.error(message || 'failed to retry deployment');
+    } finally {
+      setRetrying((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
     }
   }, []);
+
+  const handleRetryDeployment = useCallback(async (deployment: Deployment) => {
+    if (!deployment.targets.some((t: DeploymentTarget) => t.status === 'failed')) {
+      toast.error('no failed targets to retry');
+      return;
+    }
+    await runRetry(deployment);
+  }, [runRetry]);
+
+  const handleRetryTarget = useCallback(async (deployment: Deployment, machineId: string) => {
+    await runRetry(deployment, [machineId]);
+  }, [runRetry]);
 
   // Load saved site from Firestore (cross-browser) or localStorage (same-browser fallback)
   useEffect(() => {
@@ -580,6 +621,8 @@ export default function DeploymentsPage() {
                   isSelected={selectedDeploymentId === deployment.id}
                   onToggle={handleToggleDeployment}
                   onRetry={handleRetryDeployment}
+                  onRetryTarget={handleRetryTarget}
+                  retrying={retrying}
                   onUninstall={handleUninstallFromRow}
                   onDelete={handleDeleteFromRow}
                   onCancel={handleCancelTarget}

--- a/web/components/DeploymentDialog.tsx
+++ b/web/components/DeploymentDialog.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -581,12 +582,15 @@ export default function DeploymentDialog({
           {/* Silent Flags */}
           <div className="space-y-2">
             <Label htmlFor="silent-flags" className="text-white">silent install flags</Label>
-            <Input
+            <Textarea
               id="silent-flags"
               placeholder='/VERYSILENT /DIR="C:\\Program Files\\App"'
               value={silentFlags}
-              onChange={(e) => setSilentFlags(e.target.value)}
-              className="border-border bg-background text-white"
+              // Flags are a single command line — wrap for readability, but
+              // collapse typed/pasted newlines so the agent's installer
+              // invocation never receives a broken multi-line string.
+              onChange={(e) => setSilentFlags(e.target.value.replace(/\s*[\r\n]+\s*/g, ' '))}
+              className="border-border bg-background text-white font-mono text-sm"
             />
             <p className="text-xs text-muted-foreground">command-line flags for silent installation</p>
           </div>

--- a/web/components/SystemPresetDialog.tsx
+++ b/web/components/SystemPresetDialog.tsx
@@ -391,11 +391,14 @@ export default function SystemPresetDialog({
             <Label htmlFor="silentFlags" className="text-white">
               silent install flags *
             </Label>
-            <Input
+            <Textarea
               id="silentFlags"
               placeholder="/VERYSILENT /NORESTART /SUPPRESSMSGBOXES"
               value={silentFlags}
-              onChange={(e) => setSilentFlags(e.target.value)}
+              // Flags are a single command line — wrap for readability, but
+              // collapse typed/pasted newlines so the agent's installer
+              // invocation never receives a broken multi-line string.
+              onChange={(e) => setSilentFlags(e.target.value.replace(/\s*[\r\n]+\s*/g, ' '))}
               className="border-border bg-background text-white font-mono text-sm"
             />
             <p className="text-xs text-muted-foreground">

--- a/web/e2e/specs/api-sprint/installer-deployments.spec.ts
+++ b/web/e2e/specs/api-sprint/installer-deployments.spec.ts
@@ -228,6 +228,9 @@ test('POST /api/sites/{s}/deployments/{id}/retry — re-queues failed targets', 
       installer_name: 'retry.exe',
       installer_url: 'https://example.com/retry.exe',
       silent_flags: '/S',
+      // Pinned checksum keeps the server's legacy self-heal (which would
+      // stream the installer URL) out of this test — network-free retry.
+      sha256_checksum: 'ab'.repeat(32),
       targets: [
         { machineId: MACHINE_ID_A, status: 'failed', error: 'boom' },
         { machineId: MACHINE_ID_B, status: 'completed' },

--- a/web/e2e/specs/dispatch/retry-deployment.spec.ts
+++ b/web/e2e/specs/dispatch/retry-deployment.spec.ts
@@ -1,17 +1,19 @@
 /**
  * Dispatch — retry failed deployment (D4.4)
  *
- * "Retry failed" doesn't mutate the original deployment — per
- * `app/deployments/page.tsx::handleRetryDeployment`, it filters the
- * deployment's targets to those with status='failed', then calls
- * `createDeployment` with name `${original.name} (Retry)` targeting
- * just those machines. End-state:
- *   - Original deployment unchanged (still has the failed target).
- *   - A NEW deployment doc exists with the retry name + the failed
- *     target as its sole target (status: 'pending').
- *   - One install_software command for that machine in commands/pending.
+ * "Retry failed" retries IN PLACE via POST
+ * /api/sites/{siteId}/deployments/{deploymentId}/retry (it no longer clones
+ * a "(Retry)" deployment). End-state:
+ *   - The SAME deployment doc flips to 'in_progress'; the failed target
+ *     resets to 'pending' with its error dropped and `retriedAt` stamped.
+ *   - One new install_software command (retry_attempt: true) in
+ *     commands/pending, carrying the deployment's sha256_checksum.
  *
- * Closes wave D4 (deployment dispatch).
+ * Two entry points share the flow: the row dropdown ("retry failed" — all
+ * failed targets) and the per-target retry icon (single machine, body
+ * `machines` filter). The seed carries a sha256_checksum so the server's
+ * legacy self-heal (which would fetch the installer URL) stays out of the
+ * loop — deterministic in the emulator env.
  */
 
 import { test, expect } from '@playwright/test';
@@ -29,6 +31,7 @@ const DEPLOYMENT_ID = `deploy-${Date.now()}`;
 const DEPLOYMENT_NAME = 'E2E Retry Deployment';
 const INSTALLER_NAME = 'retry-test.exe';
 const INSTALLER_URL = `https://example.com/${INSTALLER_NAME}`;
+const SHA256 = 'ab'.repeat(32);
 
 async function clearDeploymentsAndCommands() {
   const db = getAdminDb();
@@ -49,6 +52,7 @@ async function seedFailedDeployment() {
     installer_name: INSTALLER_NAME,
     installer_url: INSTALLER_URL,
     silent_flags: '/SILENT',
+    sha256_checksum: SHA256,
     status: 'failed',
     createdAt: Timestamp.now(),
     targets: [
@@ -57,57 +61,24 @@ async function seedFailedDeployment() {
   });
 }
 
-test.beforeEach(async () => {
-  await seedMachine(SITE_ID, MACHINE_ID);
-  await clearDeploymentsAndCommands();
-  await seedFailedDeployment();
-});
-
-test('admin retries a failed deployment — original untouched + new "(Retry)" deployment + new install command', async ({ page }) => {
-  await page.goto('/deployments');
-  await expect(page.getByRole('heading', { name: 'deployments', exact: true })).toBeVisible({ timeout: 10_000 });
-
-  // Open the deployment's actions dropdown — aria-label was added
-  // alongside this spec for a11y (icon-only MoreVertical button).
-  await page.getByRole('button', { name: `deployment actions for ${DEPLOYMENT_NAME}` }).click();
-
-  // The "retry failed" item is gated to deployments with at least one
-  // failed target — our seed satisfies that.
-  await page.getByRole('menuitem', { name: /retry failed/i }).click();
-
-  // Toast — the singular form for one machine.
-  await expect(page.getByText('retrying deployment for 1 failed machine(s)', { exact: true }))
-    .toBeVisible({ timeout: 10_000 });
-
-  // Admin SDK: a NEW deployment exists with the (Retry) suffix.
+async function assertInPlaceRetry() {
   const db = getAdminDb();
-  let retryDeploys: FirebaseFirestore.QueryDocumentSnapshot[] = [];
+
+  // Same doc mutated — no "(Retry)" clone is ever created.
+  let targets: Array<{ status: string; error?: string; retriedAt?: unknown }> = [];
   await expect.poll(async () => {
-    const snap = await db.collection('sites').doc(SITE_ID).collection('deployments').get();
-    retryDeploys = snap.docs.filter((d) => d.data().name === `${DEPLOYMENT_NAME} (Retry)`);
-    return retryDeploys.length;
-  }, { timeout: 5_000 }).toBe(1);
+    const snap = await db.collection('sites').doc(SITE_ID).collection('deployments').doc(DEPLOYMENT_ID).get();
+    targets = (snap.data()!.targets ?? []) as typeof targets;
+    return `${snap.data()!.status}:${targets[0]?.status}`;
+  }, { timeout: 10_000 }).toBe('in_progress:pending');
 
-  const retryDoc = retryDeploys[0];
-  const retryData = retryDoc.data();
-  expect(retryDoc.id).toMatch(/^deploy-\d+$/);
-  expect(retryDoc.id).not.toBe(DEPLOYMENT_ID);
-  expect(retryData.installer_url).toBe(INSTALLER_URL);
-  expect(retryData.installer_name).toBe(INSTALLER_NAME);
-  expect(retryData.targets).toHaveLength(1);
-  expect(retryData.targets[0].machineId).toBe(MACHINE_ID);
-  expect(retryData.targets[0].status).toBe('pending');
-  // No 'error' field carries over — fresh start for the retry.
-  expect(retryData.targets[0].error).toBeUndefined();
+  expect(targets[0].error).toBeUndefined();
+  expect(targets[0].retriedAt).toBeDefined();
 
-  // Original deployment is unchanged.
-  const originalSnap = await db.collection('sites').doc(SITE_ID).collection('deployments').doc(DEPLOYMENT_ID).get();
-  const originalTargets = originalSnap.data()!.targets as Array<{ status: string; error?: string }>;
-  expect(originalTargets[0].status).toBe('failed');
-  expect(originalTargets[0].error).toBe('install exited with code 1603');
+  const allDeploys = await db.collection('sites').doc(SITE_ID).collection('deployments').get();
+  expect(allDeploys.docs).toHaveLength(1);
 
-  // A new install_software command landed in pending tied to the new
-  // retry deployment id.
+  // New install command tied to the ORIGINAL deployment id, checksum intact.
   const pendingIds = await getPendingCommandIds(SITE_ID, MACHINE_ID);
   const installKeys = pendingIds.filter((id) => id.startsWith('install_'));
   expect(installKeys).toHaveLength(1);
@@ -118,6 +89,41 @@ test('admin retries a failed deployment — original untouched + new "(Retry)" d
     .collection('commands').doc('pending').get();
   const cmd = pendingSnap.data()![installKeys[0]];
   expect(cmd.type).toBe('install_software');
-  expect(cmd.deployment_id).toBe(retryDoc.id);
+  expect(cmd.deployment_id).toBe(DEPLOYMENT_ID);
   expect(cmd.installer_url).toBe(INSTALLER_URL);
+  expect(cmd.sha256_checksum).toBe(SHA256);
+  expect(cmd.retry_attempt).toBe(true);
+}
+
+test.beforeEach(async () => {
+  await seedMachine(SITE_ID, MACHINE_ID);
+  await clearDeploymentsAndCommands();
+  await seedFailedDeployment();
+});
+
+test('admin retries a failed deployment in place via the row dropdown', async ({ page }) => {
+  await page.goto('/deployments');
+  await expect(page.getByRole('heading', { name: 'deployments', exact: true })).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole('button', { name: `deployment actions for ${DEPLOYMENT_NAME}` }).click();
+  await page.getByRole('menuitem', { name: /retry failed/i }).click();
+
+  await expect(page.getByText('retrying deployment for 1 machine(s)', { exact: true }))
+    .toBeVisible({ timeout: 10_000 });
+
+  await assertInPlaceRetry();
+});
+
+test('admin retries a single failed target via the per-row retry icon', async ({ page }) => {
+  await page.goto('/deployments');
+  await expect(page.getByRole('heading', { name: 'deployments', exact: true })).toBeVisible({ timeout: 10_000 });
+
+  // Expand the deployment row to reveal per-target rows.
+  await page.getByText(DEPLOYMENT_NAME, { exact: true }).click();
+  await page.getByRole('button', { name: `retry deployment to ${MACHINE_ID}` }).click();
+
+  await expect(page.getByText('retrying deployment for 1 machine(s)', { exact: true }))
+    .toBeVisible({ timeout: 10_000 });
+
+  await assertInPlaceRetry();
 });

--- a/web/hooks/useDeployments.ts
+++ b/web/hooks/useDeployments.ts
@@ -235,6 +235,31 @@ export function useDeployments(siteId: string) {
     return result.deploymentId as string;
   };
 
+  /**
+   * Re-queue install commands for failed targets on an existing deployment.
+   * `machineIds` narrows the retry to specific machines (per-row retry);
+   * omitted → all failed targets. The server self-heals a missing
+   * sha256_checksum by computing it from the installer URL, so legacy
+   * deployments retry cleanly (the call may take a while for large
+   * installers while the server streams + hashes).
+   */
+  const retryDeployment = async (deploymentId: string, machineIds?: string[]) => {
+    if (!db || !siteId) throw new Error('Firebase not configured');
+
+    const response = await fetch(`${deploymentsUrl(siteId)}/${encodeURIComponent(deploymentId)}/retry`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'Idempotency-Key': makeIdempotencyKey(`deployment-retry-${deploymentId}`),
+      },
+      body: JSON.stringify(machineIds?.length ? { machines: machineIds } : {}),
+    });
+    if (!response.ok) throw new Error(await readApiError(response, 'Failed to retry deployment'));
+
+    const result = await response.json();
+    return result.retried as number;
+  };
+
   const cancelDeployment = async (deploymentId: string, machineId: string, installer_name: string) => {
     if (!db || !siteId) throw new Error('Firebase not configured');
     void machineId;
@@ -289,6 +314,7 @@ export function useDeployments(siteId: string) {
     loading,
     error,
     createDeployment,
+    retryDeployment,
     cancelDeployment,
     deleteDeployment,
     checkMachineHasActiveDeployment
@@ -312,6 +338,7 @@ export function useDeploymentManager(siteId: string) {
     deploymentsLoading: deployments.loading,
     deploymentsError: deployments.error,
     createDeployment: deployments.createDeployment,
+    retryDeployment: deployments.retryDeployment,
     cancelDeployment: deployments.cancelDeployment,
     deleteDeployment: deployments.deleteDeployment,
     checkMachineHasActiveDeployment: deployments.checkMachineHasActiveDeployment,


### PR DESCRIPTION
Follow-up to #83. Cherry-picks `eac0a53` from `dev` (clean apply, no conflicts) so the deployment fixes ship without dragging the unreleased billing sprint to prod.

## The bug behind "retry failed" still erroring

Even after #83, clicking **retry failed** returned `Refusing to install … without sha256_checksum`. Root cause: the dashboard's retry never called the retry API at all — it cloned a brand-new `<name> (Retry)` deployment via `createDeployment` **without** a checksum, so it failed on every up-to-date agent. It was broken for post-#83 deployments too.

## What changed

- **Retry goes through `POST /api/sites/{siteId}/deployments/{deploymentId}/retry`** and retries **in place**: the same deployment record flips to `in_progress`, failed targets reset to `pending` with their error dropped and `retriedAt` stamped. No more duplicate `(Retry)` clone records accumulating in the list.
- **Self-healing checksums**: retrying a legacy (pre-#83) deployment computes the SHA-256 from the installer URL, pins it on the deployment doc, and stamps it into every re-issued command. A compute failure returns the error instead of queuing commands agents would refuse. Subsequent retries reuse the pinned value.
- **Per-target retry icon** on failed target rows (spinner + disabled while in flight), backed by a new optional `machines` filter on the retry endpoint (validated) and `useDeployments.retryDeployment(deploymentId, machineIds?)`.
- **Silent flags → multi-line**: single-line `Input` → auto-growing `Textarea` in both the deploy and system-preset dialogs. Typed/pasted newlines collapse to spaces so the stored value stays a valid single command line for the agent's installer invocation.
- **Fixed the invisible "in progress" pill** — it was the only status with no color mapped, falling through to a transparent default. Now cyan, matching its spinner icon.

## Behavior change worth flagging

Retry is now **in-place** rather than cloning a new deployment. Deployment history shows one record per deployment instead of a chain of `(Retry)` duplicates. The `retry-deployment` e2e spec was rewritten to pin the new contract.

## Verification

- Local preflight on dev: lint ✅ typecheck ✅ 3606 unit tests ✅ full e2e **297 passed** ✅
- New coverage: 5 retry-route unit cases (machines filter, self-heal, stored-checksum passthrough, compute failure, malformed filter); e2e tests for both in-place dropdown retry and the per-row icon
- dev CI green on `eac0a53`; this PR's e2e run validates the diff against `main` without billing present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
