### PR TITLE
fix(security): bump bundled cryptography to 50.0.0 (cherry-pick to main)

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -3,7 +3,7 @@ psutil==5.9.5
 pystray==0.19.4
 email-validator==2.0.0
 GPUtil==1.4.0
-cryptography>=44.0.0,<45.0.0
+cryptography>=50.0.0,<51.0.0
 google-auth==2.22.0
 google-api-python-client==2.98.0
 google-auth-oauthlib==1.0.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ All notable changes to owlette are documented here. The format is based on [Keep
 
 ---
 
-## [2.12.19] - 2026-07-15
+## [2.12.19] - 2026-08-07
 
 ### added
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,10 @@ All notable changes to owlette are documented here. The format is based on [Keep
 
 - **Offline alert emails are consolidated and accurate.** When several machines at a site go offline around the same time, one email now lists the full picture — machines not responding, machines that reported shutting down, and machines still offline from an earlier alert — with a subject count that matches the list. Previously a staggered site-wide outage produced several emails with partial counts. Alerts wait for the situation to stabilize (about ten minutes) before sending.
 
+### security
+
+- **The bundled cryptography library is updated to 50.0.0.** This clears three published advisories against the previous version (CVE-2026-69247, CVE-2026-69249, CVE-2026-69248). None of them were reachable from owlette — the affected PKCS#7 decryption and X.509 chain-verification routines are not used by the agent, which relies on the library only for token encryption and device-code pairing. The update keeps the bundled dependency clean for operators who run vulnerability scanners against their machines.
+
 ## [2.12.18] - 2026-07-09
 
 ### fixed

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -26,6 +26,10 @@ description: "All notable changes to owlette are documented here. The format is 
 
 - **Offline alert emails are consolidated and accurate.** When several machines at a site go offline around the same time, one email now lists the full picture — machines not responding, machines that reported shutting down, and machines still offline from an earlier alert — with a subject count that matches the list. Previously a staggered site-wide outage produced several emails with partial counts. Alerts wait for the situation to stabilize (about ten minutes) before sending.
 
+### security
+
+- **The bundled cryptography library is updated to 50.0.0.** This clears three published advisories against the previous version (CVE-2026-69247, CVE-2026-69249, CVE-2026-69248). None of them were reachable from owlette — the affected PKCS#7 decryption and X.509 chain-verification routines are not used by the agent, which relies on the library only for token encryption and device-code pairing. The update keeps the bundled dependency clean for operators who run vulnerability scanners against their machines.
+
 ## [2.12.18] - 2026-07-09
 
 ### fixed

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -5,7 +5,7 @@ description: "All notable changes to owlette are documented here. The format is 
 
 ---
 
-## [2.12.19] - 2026-07-15
+## [2.12.19] - 2026-08-07
 
 ### added
 


### PR DESCRIPTION
Cherry-pick of `3b4fca8` from `dev`, isolated so the cryptography CVEs can be closed on the default branch **without** shipping the 21-commit `dev` backlog (billing waves 0–5, deployments, auth, landing). PR #86 remains a draft for that.

## Closes 3 Dependabot alerts

Dependabot computes alerts against the default branch, so this merge is what actually closes them:

| Alert | CVE | Sev | Vulnerable | Patched |
|---|---|---|---|---|
| #195 | CVE-2026-69247 — PKCS#7 EnvelopedData Bleichenbacher oracle | High | `>=44.0.0, <50.0.0` | 50.0.0 |
| #197 | CVE-2026-69249 — exponential cert path-building DoS | High | `<=48.0.0` | 49.0.0 |
| #198 | CVE-2026-69248 — wildcard DNS escapes `permittedSubtrees` | Medium | `<=48.0.0` | 49.0.0 |

## None were reachable

The agent's entire cryptography surface is `Fernet` (`secure_storage.py:25`) and `hashes`/`AESGCM`/`HKDF` (`auth_manager.py:37-39`). No PKCS#7, no `cryptography.x509.verification`, and no transitive consumer of either — verified by importing the agent's full 26-module third-party closure and confirming `cryptography.x509` never loads. This is a hygiene fix, not an incident.

## Verification

Independently re-run by adversarial review:

- **Token compatibility, both directions.** Fernet / HKDF-SHA256 / AESGCM round-trip between 44.0.3 and 50.0.0 against the real `secure_storage.py` and `auth_manager.py`, so existing `.tokens.enc` files keep decrypting and rollback is safe. Note HKDF was reimplemented pure-Python → Rust/OpenSSL across this span; verified output-identical.
- **Fernet now caches its AES object**, and the agent shares one `Fernet` across threads via `get_storage()`. Stress-tested 16 threads × 300 ops, 0 errors on both versions.
- `cryptography-50.0.0-cp311-abi3-win_amd64` wheel matches the bundled Python 3.11.8; full requirements set resolves clean.
- Installer 2.12.19 built with this pin and live on dev — `sha256 4081945d726d75c9b1d4a17690dd1d9f9e9a24e1e54a0d4dec36b0021092afea`.

## Second commit: changelog date

`main`'s 2.12.19 heading read 2026-07-15 (when the work finished); the release actually happened 2026-08-07 per the installer API. Without this, the cherry-pick would file a CVE fix authored 2026-08-07 under a release dated three weeks earlier. Matches the correction already on `dev` (`3fe0ed5`), so the eventual `dev`→`main` merge sees identical content.

## Scope

Three files: `agent/requirements.txt`, `docs/changelog.md`, `web/content/docs/changelog.mdx`. No billing, no app code.

`main` carries the range `>=50.0.0,<51.0.0` from this pick; `dev` has since tightened it to `==50.0.0` (`8dd3db6`). That converges on the full merge.

## Not fixed here

The other 5 `agent/requirements.txt` alerts — setuptools #5/#8, requests #4/#6/#7 — remain open on both branches. All five verified unreachable; PR #80 addresses them, targeted at 2.12.20 along with the `--ignore-installed` build defect that currently ships duplicate dist-info metadata to every machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
