### PR TITLE
name the browser tab after the page

### DIFF
--- a/web/__tests__/app/share-page.test.tsx
+++ b/web/__tests__/app/share-page.test.tsx
@@ -244,7 +244,13 @@ describe('/share/[token] generateMetadata', () => {
     const metadata = await generateMetadata(props());
 
     expect(metadata.robots).toEqual({ index: false, follow: false, nocache: true });
-    expect(metadata.title).toBe('why did the render node drop offline — shared from owlette hoot');
+    // `absolute`, not a bare string: the root layout templates titles as
+    // "owlette - %s", and this one already carries the brand. Asserting the
+    // shape is the point — a plain string here would silently become
+    // "owlette - … — shared from owlette hoot" on a public page.
+    expect(metadata.title).toEqual({
+      absolute: 'why did the render node drop offline — shared from owlette hoot',
+    });
     expect(metadata.description).toBe('why did the render node drop offline last night?');
     expect(metadata.openGraph).toMatchObject({ type: 'article' });
     expect(metadata.twitter).toMatchObject({ card: 'summary_large_image' });
@@ -290,7 +296,7 @@ describe('/share/[token] generateMetadata', () => {
     const metadata = await generateMetadata(props());
 
     expect(metadata.robots).toEqual({ index: false, follow: false, nocache: true });
-    expect(metadata.title).toBe('shared conversation not available');
+    expect(metadata.title).toEqual({ absolute: 'shared conversation not available' });
     expect(String(metadata.description)).not.toMatch(/revoked|deleted/i);
   });
 });

--- a/web/app/add/layout.tsx
+++ b/web/app/add/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `add/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'add a machine',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/admin/alerts/layout.tsx
+++ b/web/app/admin/alerts/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `admin/alerts/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'admin · alerts',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/admin/email/layout.tsx
+++ b/web/app/admin/email/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `admin/email/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'admin · email',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/admin/installers/layout.tsx
+++ b/web/app/admin/installers/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `admin/installers/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'admin · installers',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/admin/members/layout.tsx
+++ b/web/app/admin/members/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `admin/members/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'admin · members',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/admin/presets/layout.tsx
+++ b/web/app/admin/presets/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `admin/presets/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'admin · presets',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/admin/schedules/layout.tsx
+++ b/web/app/admin/schedules/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `admin/schedules/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'admin · schedules',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/admin/tokens/layout.tsx
+++ b/web/app/admin/tokens/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `admin/tokens/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'admin · tokens',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/admin/users/layout.tsx
+++ b/web/app/admin/users/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `admin/users/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'admin · users',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/admin/webhooks/layout.tsx
+++ b/web/app/admin/webhooks/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `admin/webhooks/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'admin · webhooks',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/cli/authorize/layout.tsx
+++ b/web/app/cli/authorize/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `cli/authorize/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'authorize cli',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/dashboard/layout.tsx
+++ b/web/app/dashboard/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `dashboard/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'dashboard',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/deployments/layout.tsx
+++ b/web/app/deployments/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `deployments/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'deploy',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/for-ai/page.tsx
+++ b/web/app/for-ai/page.tsx
@@ -20,7 +20,9 @@ import {
 } from "@/lib/product-facts";
 
 export const metadata: Metadata = {
-  title: "owlette — for AI assistants",
+  // `absolute` opts out of the root layout's "owlette - %s" template: this
+  // title already carries the brand, and the template would double it.
+  title: { absolute: "owlette — for AI assistants" },
   description:
 "Facts and guardrails for AI assistants reading, summarizing, or recommending owlette — an agent and cloud dashboard for monitoring, managing, and deploying software across fleets of Windows machines.",
   alternates: {

--- a/web/app/forgot-password/layout.tsx
+++ b/web/app/forgot-password/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `forgot-password/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'reset password',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/hoot/[chatId]/page.tsx
+++ b/web/app/hoot/[chatId]/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'hoot',
+};
+
 // The Hoot view is rendered by the persistent layout (app/hoot/layout.tsx),
 // which derives the active chat id from the pathname. This page exists only so
 // the /hoot/[chatId] route resolves.

--- a/web/app/hoot/page.tsx
+++ b/web/app/hoot/page.tsx
@@ -1,6 +1,16 @@
 // The Hoot view is rendered by the persistent layout (app/hoot/layout.tsx),
 // which derives the active chat id from the pathname. This page exists only so
 // the /hoot route resolves.
+//
+// The tab title lives here rather than in that layout: the layout is a client
+// component (it holds the chat view across /hoot <-> /hoot/[chatId]
+// navigations), and a 'use client' module cannot export `metadata`.
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'hoot',
+};
+
 export default function HootPage() {
   return null;
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -25,7 +25,17 @@ const siteUrl = process.env.RAILWAY_PUBLIC_DOMAIN
   : 'https://owlette.app';
 
 export const metadata: Metadata = {
-  title: "owlette — keep every windows machine running",
+  title: {
+    default: "owlette — keep every windows machine running",
+    // Every app route sets a short lowercase name (the nav label) and gets
+    // "owlette - <name>" in the tab.
+    //
+    // Pages whose title ALREADY carries the brand opt out with `absolute`, or
+    // the template doubles it: /for-ai and /share/[token]. Docs pages
+    // deliberately do NOT opt out — they set a bare page name, so the template
+    // is what gives them "owlette - Getting Started" instead of a brandless tab.
+    template: "owlette - %s",
+  },
   description: "owlette keeps your installations running 24/7 — remote monitoring, auto-recovery, and AI-powered fleet management for Windows machines.",
   icons: {
     icon: '/icon.svg',

--- a/web/app/legal/dmca/layout.tsx
+++ b/web/app/legal/dmca/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `legal/dmca/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'dmca',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/login/layout.tsx
+++ b/web/app/login/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `login/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'sign in',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/logs/layout.tsx
+++ b/web/app/logs/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `logs/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'logs',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/privacy/layout.tsx
+++ b/web/app/privacy/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `privacy/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'privacy',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/register/layout.tsx
+++ b/web/app/register/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `register/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'create account',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/reset-password/layout.tsx
+++ b/web/app/reset-password/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `reset-password/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'reset password',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/roosts/page.tsx
+++ b/web/app/roosts/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'roost',
+};
+
 import { Suspense } from 'react';
 import { connection } from 'next/server';
 import RoostsPageClient from './RoostsPageClient';

--- a/web/app/settings/alerts/layout.tsx
+++ b/web/app/settings/alerts/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `settings/alerts/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'alerts',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/settings/api-keys/layout.tsx
+++ b/web/app/settings/api-keys/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `settings/api-keys/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'api keys',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/settings/webhooks/layout.tsx
+++ b/web/app/settings/webhooks/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `settings/webhooks/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'webhooks',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/setup-2fa/layout.tsx
+++ b/web/app/setup-2fa/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `setup-2fa/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'set up 2fa',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/setup/layout.tsx
+++ b/web/app/setup/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `setup/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'setup',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/share/[token]/page.tsx
+++ b/web/app/share/[token]/page.tsx
@@ -128,7 +128,10 @@ export async function generateMetadata({ params }: SharePageProps): Promise<Meta
 
   if (!share) {
     return {
-      title: NOT_AVAILABLE_TITLE,
+      // `absolute` throughout this file: the root layout templates app titles
+      // as "owlette - %s", and these are public pages whose titles already
+      // carry their own branding.
+      title: { absolute: NOT_AVAILABLE_TITLE },
       description: NOT_AVAILABLE_DESCRIPTION,
       robots: SHARE_ROBOTS,
       // Stated rather than inherited: without these the root layout's marketing
@@ -150,7 +153,7 @@ export async function generateMetadata({ params }: SharePageProps): Promise<Meta
   const description = shareDescription(share);
 
   return {
-    title,
+    title: { absolute: title },
     description,
     robots: SHARE_ROBOTS,
     // `images` is deliberately ABSENT from both blocks. Next fills og:image and

--- a/web/app/talons/layout.tsx
+++ b/web/app/talons/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `talons/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'talons',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/terms/layout.tsx
+++ b/web/app/terms/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `terms/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'terms',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/unsubscribe/layout.tsx
+++ b/web/app/unsubscribe/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `unsubscribe/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'unsubscribe',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/app/verify-2fa/layout.tsx
+++ b/web/app/verify-2fa/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Title-only layout. `verify-2fa/page.tsx` is a client component, and a
+ * 'use client' module cannot export `metadata` — so the tab name lives here.
+ * Renders children unchanged; it exists purely for the title.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'verify',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.53",


### PR DESCRIPTION
Every app route inherited the root layout's marketing title, so the tab read "owlette — keep every windows machine running" on the dashboard, on hoot, on logs, and on every settings and admin screen. Several owlette tabs open at once were indistinguishable.

The root layout now carries a `owlette - %s` template and each route sets the short lowercase name it already uses in the nav — taken from `NAV_ITEMS` in `components/PageHeader.tsx` rather than inventing a second vocabulary, so `/deployments` is **deploy** and `/roosts` is **roost**.

Most app pages are client components and a `'use client'` module cannot export `metadata`, so those get a title-only server layout beside the page that renders children unchanged. Where the page is already a server component the metadata sits on the page: `/roosts`, `/hoot`, `/hoot/[chatId]`. `/hoot` is the interesting one — its layout is deliberately a client component so the chat view survives navigation between `/hoot` and `/hoot/[chatId]`, so the title lives on the page that renders `null`.

**Two pages opt out with `absolute`**, because their titles already carry the brand and the template would double it: `/for-ai` and `/share/[token]`, which is public and unfurls. `share-page.test.tsx` now asserts that shape rather than a bare string — a plain string there is exactly the regression that would rebrand a public page.

**Docs deliberately do not opt out**: they set a bare page name, so the template is what turns a brandless "Getting Started" into "owlette - Getting Started".

## Verified on the deployed dev site

```
/login            owlette - sign in
/register         owlette - create account
/docs/changelog   owlette - changelog
/for-ai           owlette — for AI assistants   ← correctly not prefixed
```

Authenticated routes 307 to `/login` unauthenticated, so their titles ride the identical mechanism rather than direct observation.

CI on dev: **playwright e2e 394 passed**, jest 257 suites / 5144 passed, tsc and eslint clean, next build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)